### PR TITLE
GSR: Add FeatureCount Model to enable `returnCountOnly` feature query

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -72,6 +72,8 @@ public class QueryController extends AbstractGSRController {
                     String outFieldsText,
             @RequestParam(name = "returnIdsOnly", required = false, defaultValue = "false")
                     boolean returnIdsOnly,
+            @RequestParam(name = "returnCountOnly", required = false, defaultValue = "false")
+                    boolean returnCountOnly,
             @RequestParam(name = "quantizationParameters", required = false)
                     String quantizationParameters)
             throws IOException {
@@ -98,6 +100,8 @@ public class QueryController extends AbstractGSRController {
                         layersAndTables);
         if (returnIdsOnly) {
             return FeatureEncoder.objectIds(features);
+        } else if (returnCountOnly) {
+            return FeatureEncoder.count(features);
         } else {
             FeatureList featureList =
                     new FeatureList(features, returnGeometry, outSRText, quantizationParameters);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/Feature.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/Feature.java
@@ -27,8 +27,6 @@ public class Feature {
 
     private Map<String, Object> attributes;
 
-    private Object id;
-
     public Geometry getGeometry() {
         return geometry;
     }
@@ -37,10 +35,9 @@ public class Feature {
         this.geometry = geometry;
     }
 
-    public Feature(Geometry geometry, Map<String, Object> attributes, Object id) {
+    public Feature(Geometry geometry, Map<String, Object> attributes) {
 
         super();
-        this.id = id;
         this.geometry = geometry;
         this.attributes = attributes;
     }
@@ -51,13 +48,5 @@ public class Feature {
 
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
-    }
-
-    public Object getId() {
-        return id;
-    }
-
-    public void setId(Object id) {
-        this.id = id;
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureCount.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureCount.java
@@ -1,0 +1,31 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+/* Copyright (c) 2024 Koordinates Limited. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+ package org.geoserver.gsr.model.feature;
+
+ import org.geoserver.gsr.model.GSRModel;
+ 
+ public class FeatureCount implements GSRModel {
+
+    private int count;
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public FeatureCount(int count) {
+        super();
+        this.count = count;
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureCount.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureCount.java
@@ -8,11 +8,11 @@
  * application directory.
  */
 
- package org.geoserver.gsr.model.feature;
+package org.geoserver.gsr.model.feature;
 
- import org.geoserver.gsr.model.GSRModel;
- 
- public class FeatureCount implements GSRModel {
+import org.geoserver.gsr.model.GSRModel;
+
+public class FeatureCount implements GSRModel {
 
     private int count;
 

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/map/AbstractLayerOrTable.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/map/AbstractLayerOrTable.java
@@ -158,7 +158,7 @@ public abstract class AbstractLayerOrTable extends AbstractGSRModel implements G
                         new Field(
                                 FeatureEncoder.OBJECTID_FIELD_NAME,
                                 FieldTypeEnum.OID,
-                                "Feature Id",
+                                FeatureEncoder.OBJECTID_FIELD_NAME,
                                 4000,
                                 false,
                                 false));

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/map/AbstractLayerOrTable.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/map/AbstractLayerOrTable.java
@@ -117,7 +117,7 @@ public abstract class AbstractLayerOrTable extends AbstractGSRModel implements G
             throws IOException {
         this.layer = layer;
         this.id = id;
-        this.name = layer.getName();
+        this.name = layer.getTitle();
         this.description = layer.getAbstract() == null ? "" : layer.getAbstract();
 
         copyrightText = copyrightText(layer);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
@@ -269,4 +269,10 @@ public class FeatureEncoder {
         Field idField = new Field(objectIdFieldName, FieldTypeEnum.OID, objectIdFieldName);
         return idField;
     }
+
+    public static <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureCount count(
+            FeatureCollection<T, F> features) {
+        int count = features.size();
+        return new FeatureCount(count);
+    }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
@@ -93,7 +93,7 @@ public class FeatureEncoder {
             attributes.put((String) key, jsonAttributes.get(key));
         }
 
-        return new Feature(geometry, attributes, json.get("id"));
+        return new Feature(geometry, attributes);
     }
 
     public static Feature feature(
@@ -130,10 +130,9 @@ public class FeatureEncoder {
                     geometryEncoder.toRepresentation(
                             (org.locationtech.jts.geom.Geometry) geometryAttribute.getValue(),
                             spatialReference),
-                    attributes,
-                    feature.getIdentifier().getID());
+                    attributes);
         } else {
-            return new Feature(null, attributes, feature.getIdentifier().getID());
+            return new Feature(null, attributes);
         }
     }
 

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -455,6 +455,16 @@ public class QueryControllerTest extends ControllerTest {
     }
 
     @Test
+    public void testReturnCountOnly() throws Exception {
+        String result =
+                getAsString(query("cite", 11, "?returnCountOnly=true&f=json&returnGeometry=false"));
+        JSONObject json = JSONObject.fromObject(result);
+        int count = json.getInt("count");
+
+        assertTrue("FeatureCount result was: " + result, count == 2);
+    }
+
+    @Test
     public void testBasicQuery() throws Exception {
         String query =
                 getBaseURL()

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/model/feature/FeatureSchemaTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/model/feature/FeatureSchemaTest.java
@@ -37,7 +37,7 @@ public class FeatureSchemaTest extends JsonSchemaTest {
         attributes.add(
                 new Attribute(
                         "LASTUPDATE", 1227663551096L)); // Date encoded as milliseconds since epoch
-        Feature feature = new Feature(geometry, null, "1");
+        Feature feature = new Feature(geometry, null);
         String json = getJson(feature);
         // System.out.println(json);
         assertTrue(validateJSON(json, "gsr/1.0/feature.json"));

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/translate/feature/FeatureDAOTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/translate/feature/FeatureDAOTest.java
@@ -64,7 +64,7 @@ public class FeatureDAOTest extends GeoServerSystemTestSupport {
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", "t0002");
-        Feature feature = new Feature(geom, attributes, "1");
+        Feature feature = new Feature(geom, attributes);
 
         EditResult result = FeatureDAO.createFeature(fti, FeatureDAO.featureStore(fti), feature);
         assertTrue(
@@ -107,7 +107,7 @@ public class FeatureDAOTest extends GeoServerSystemTestSupport {
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", "t0002");
-        Feature feature = new Feature(geom, attributes, "1");
+        Feature feature = new Feature(geom, attributes);
 
         EditResult result = FeatureDAO.createFeature(fti, FeatureDAO.featureStore(fti), feature);
         assertTrue(
@@ -156,7 +156,7 @@ public class FeatureDAOTest extends GeoServerSystemTestSupport {
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", "t0002");
-        Feature feature = new Feature(geom, attributes, "1");
+        Feature feature = new Feature(geom, attributes);
 
         EditResult result = FeatureDAO.createFeature(fti, FeatureDAO.featureStore(fti), feature);
         assertTrue(
@@ -205,7 +205,7 @@ public class FeatureDAOTest extends GeoServerSystemTestSupport {
         Map<String, Object> attributes = new HashMap<>();
         attributes.put(FeatureEncoder.OBJECTID_FIELD_NAME, 0L);
         attributes.put("id", "t0001");
-        Feature feature = new Feature(geom, attributes, "1");
+        Feature feature = new Feature(geom, attributes);
 
         EditResult result = FeatureDAO.updateFeature(fti, FeatureDAO.featureStore(fti), feature);
         assertNull(
@@ -249,7 +249,7 @@ public class FeatureDAOTest extends GeoServerSystemTestSupport {
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put(FeatureEncoder.OBJECTID_FIELD_NAME, 1L);
-        Feature feature = new Feature(geom, attributes, "1");
+        Feature feature = new Feature(geom, attributes);
 
         EditResult result = FeatureDAO.updateFeature(fti, FeatureDAO.featureStore(fti), feature);
         assertFalse(result.getSuccess());


### PR DESCRIPTION
This PR also has some other minor improvements, such as:
- Removing the feature ID from the feature object (It is already inside `feature.attributes`)
- Keeping the objectid alias consistent with the field name
- Set the name of the feature layer to its title

### Checklist

- [x] I've reviewed the diff myself
- [x] Tests have been updated
<!-- Any other things that need to be done before merging? Add them here. -->

### Why you made these changes?
With our current PoC we're able to _attempt_ to load data into ArcPro, however the actual geometry/attribute data isn't loaded. ArcPro correctly zooms to the right area, and the attribute table has the right column names, but the data itself doesn't load.

Debugging with Charles Proxy; ArcPRO was making a query request with `returnCountOnly=true`. However, this parameter wasn't enabled for GSR. It was expecting a response with `"count": 123` but was returning a normal `/query` response. 

It was confirmed that it was making this request with KoopJS as well, but Koop's endpoint was showing the correct number of feature counts. 

### How have you solved the problem?
Added the `returnCountOnly` query parameter to the query endpoint. 

### Risks involved
There shouldn't be any.

#### Are there possible or actual performance implications for this change?
Possibly when iterating through large number of features?

### Deployment/Migration

