### PR TITLE
GSR: Re-arrange layers within the GSR service index

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/catalog/CatalogServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/catalog/CatalogServiceController.java
@@ -131,7 +131,9 @@ public class CatalogServiceController extends AbstractGSRController {
                     "Layer name " + layerName + " does not correspond to any valid layers.");
         }
         fillServices(services, li, workspaceName);
-        services.add(new GeometryService("Geometry"));
+        if (!GeometryService.isGeometryServiceDisabled()) {
+            services.add(new GeometryService("Geometry"));
+        }
         CatalogService catalog =
                 new CatalogService(
                         layerName,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureController.java
@@ -38,7 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller for the Feature Service feature list endpoint */
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName}/FeatureServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/FeatureServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class FeatureController extends AbstractGSRController {
 
@@ -47,24 +47,28 @@ public class FeatureController extends AbstractGSRController {
         super(geoServer);
     }
 
-    @GetMapping(path = "/{layerId}/{featureId}", name = "MapServerGetLegend")
+    @GetMapping(path = "/{layerId}/{featureId:^(?!query$).*$}", name = "FeatureServerGetLegend")
     @HTMLResponseBody(templateName = "featureitem.ftl", fileName = "featureitem.html")
     public FeatureWrapper getFeature(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable Integer layerId,
             @PathVariable String featureId)
             throws IOException, FactoryException {
-        LayerOrTable l = LayerDAO.find(catalog, workspaceName, layerId);
+        LayerOrTable l = LayerDAO.find(catalog, workspaceName, layerName, layerId);
 
         if (null == l) {
             throw new NoSuchElementException(
-                    "No table or layer in workspace \"" + workspaceName + "\" for id " + layerId);
+                    "No table or layer in workspace \""
+                            + workspaceName
+                            + "\" for name "
+                            + layerName);
         }
 
         FeatureTypeInfo featureType = (FeatureTypeInfo) l.layer.getResource();
         if (null == featureType) {
             throw new NoSuchElementException(
-                    "No table or layer in workspace \"" + workspaceName + "\" for id " + layerId);
+                    "No table or layer in workspace \"" + workspaceName + "\" for id " + layerName);
         }
 
         Filter idFilter =
@@ -94,14 +98,22 @@ public class FeatureController extends AbstractGSRController {
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "FeatureServer", "FeatureServer"),
+                                new Link(workspaceName + "/" + layerName, layerName),
                                 new Link(
-                                        workspaceName + "/" + "FeatureServer/" + layerId,
+                                        workspaceName + "/" + layerName + "/FeatureServer",
+                                        "FeatureServer"),
+                                new Link(
+                                        workspaceName
+                                                + "/"
+                                                + layerName
+                                                + "/FeatureServer/"
+                                                + layerId,
                                         l.getName()),
                                 new Link(
                                         workspaceName
                                                 + "/"
-                                                + "FeatureServer/"
+                                                + layerName
+                                                + "/FeatureServer/"
                                                 + layerId
                                                 + "/"
                                                 + featureId,
@@ -111,7 +123,8 @@ public class FeatureController extends AbstractGSRController {
                         new Link(
                                 workspaceName
                                         + "/"
-                                        + "FeatureServer/"
+                                        + layerName
+                                        + "/FeatureServer/"
                                         + layerId
                                         + "/"
                                         + featureId

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -24,9 +24,6 @@ import org.geoserver.gsr.api.AbstractGSRController;
 import org.geoserver.gsr.api.ServiceException;
 import org.geoserver.gsr.model.AbstractGSRModel.Link;
 import org.geoserver.gsr.model.feature.*;
-import org.geoserver.gsr.model.feature.EditResults;
-import org.geoserver.gsr.model.feature.Feature;
-import org.geoserver.gsr.model.feature.FeatureArray;
 import org.geoserver.gsr.model.map.LayerOrTable;
 import org.geoserver.gsr.translate.feature.FeatureDAO;
 import org.geoserver.gsr.translate.feature.FeatureEncoder;
@@ -42,7 +39,7 @@ import org.springframework.web.bind.annotation.*;
 /** Controller for the Feature Service layer endpoint */
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName}/FeatureServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/FeatureServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class FeatureLayerController extends AbstractGSRController {
     private static final Logger LOGGER =
@@ -57,36 +54,52 @@ public class FeatureLayerController extends AbstractGSRController {
     @GetMapping(path = "/{layerId}", name = "FeatureServerGetFeature")
     @HTMLResponseBody(templateName = "featurelayer.ftl", fileName = "featurelayer.html")
     public FeatureLayer featureGet(
-            @PathVariable String workspaceName, @PathVariable Integer layerId) throws IOException {
+            @PathVariable String workspaceName,
+            @PathVariable String layerName,
+            @PathVariable Integer layerId)
+            throws IOException {
         LayerOrTable entry;
         try {
-            entry = LayerDAO.find(catalog, workspaceName, layerId);
+            entry = LayerDAO.find(catalog, workspaceName, layerName, layerId);
         } catch (IOException e) {
             throw new NoSuchElementException(
                     "Unavailable table or layer in workspace \""
                             + workspaceName
-                            + "\" for id "
-                            + layerId
+                            + "\" for name "
+                            + layerName
                             + ":"
                             + e);
         }
         if (entry == null) {
             throw new NoSuchElementException(
-                    "No table or layer in workspace \"" + workspaceName + "\" for id " + layerId);
+                    "No table or layer in workspace \""
+                            + workspaceName
+                            + "\" for name "
+                            + layerName);
         }
         FeatureLayer layer = new FeatureLayer(entry);
         layer.getPath()
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "FeatureServer", "FeatureServer"),
+                                new Link(workspaceName + "/" + layerName, layerName),
                                 new Link(
-                                        workspaceName + "/" + "FeatureServer/" + layerId,
+                                        workspaceName + "/" + layerName + "/" + "FeatureServer",
+                                        "FeatureServer"),
+                                new Link(
+                                        workspaceName
+                                                + "/"
+                                                + layerName
+                                                + "/"
+                                                + "FeatureServer/"
+                                                + layerId,
                                         entry.getName())));
         layer.getInterfaces()
                 .add(
                         new Link(
                                 workspaceName
+                                        + "/"
+                                        + layerName
                                         + "/"
                                         + "FeatureServer/"
                                         + layerId
@@ -130,6 +143,7 @@ public class FeatureLayerController extends AbstractGSRController {
             name = "FeatureServerDeleteFeatures")
     public EditResults featureDelete(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable Integer layerId,
             @RequestParam(name = "objectIds", required = false) String objectIdsText,
             @RequestParam(name = "geometryType", required = false) String geometryTypeName,
@@ -145,6 +159,7 @@ public class FeatureLayerController extends AbstractGSRController {
 
         return deleteFeatures(
                 workspaceName,
+                layerName,
                 layerId,
                 objectIdsText,
                 geometryTypeName,
@@ -159,6 +174,7 @@ public class FeatureLayerController extends AbstractGSRController {
     /** @See FeatureLayerController#featureDelete */
     private EditResults deleteFeatures(
             String workspaceName,
+            String layerName,
             Integer layerId,
             String objectIdsText,
             String geometryTypeName,
@@ -171,10 +187,13 @@ public class FeatureLayerController extends AbstractGSRController {
             throws IOException, ServiceException {
         LayerOrTable entry;
 
-        entry = LayerDAO.find(catalog, workspaceName, layerId);
+        entry = LayerDAO.find(catalog, workspaceName, layerName, layerId);
         if (entry == null) {
             throw new NoSuchElementException(
-                    "No table or layer in workspace \"" + workspaceName + "\" for id " + layerId);
+                    "No table or layer in workspace \""
+                            + workspaceName
+                            + "\" for layer "
+                            + layerName);
         }
         LayerInfo l = entry.layer;
         FeatureCollection features =
@@ -205,6 +224,7 @@ public class FeatureLayerController extends AbstractGSRController {
     /** @See FeatureLayerController#featureDelete */
     private EditResults deleteFeatures(
             String workspaceName,
+            String layerName,
             Integer layerId,
             String objectIdsText,
             boolean rollbackOnFailure,
@@ -212,6 +232,7 @@ public class FeatureLayerController extends AbstractGSRController {
             throws IOException, ServiceException {
         return deleteFeatures(
                 workspaceName,
+                layerName,
                 layerId,
                 objectIdsText,
                 null,
@@ -248,6 +269,7 @@ public class FeatureLayerController extends AbstractGSRController {
             name = "FeatureServerUpdateFeatures")
     public EditResults updateFeaturesPost(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable Integer layerId,
             @RequestParam String features,
             @RequestParam(name = "rollbackOnFailure", required = false, defaultValue = "false")
@@ -257,13 +279,19 @@ public class FeatureLayerController extends AbstractGSRController {
             throws IOException, ServiceException {
         FeatureArray featureArray = jsonStringToFeatureArray(features);
         return updateFeatures(
-                featureArray, workspaceName, layerId, rollbackOnFailure, returnEditMoment);
+                featureArray,
+                workspaceName,
+                layerName,
+                layerId,
+                rollbackOnFailure,
+                returnEditMoment);
     }
 
     /** @See FeatureLayerController#updateFeaturesPost */
     private EditResults updateFeatures(
             FeatureArray featureArray,
             String workspaceName,
+            String layerName,
             Integer layerId,
             boolean rollbackOnFailure,
             boolean returnEditMoment)
@@ -273,7 +301,7 @@ public class FeatureLayerController extends AbstractGSRController {
             throw new IllegalArgumentException("No features provided");
         }
 
-        LayerInfo layer = featureGet(workspaceName, layerId).layer;
+        LayerInfo layer = featureGet(workspaceName, layerName, layerId).layer;
 
         if (layer.getResource() instanceof FeatureTypeInfo) {
             FeatureTypeInfo fti = (FeatureTypeInfo) layer.getResource();
@@ -304,6 +332,7 @@ public class FeatureLayerController extends AbstractGSRController {
             name = "FeatureServerAddFeatures")
     public EditResults addFeaturesPost(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable Integer layerId,
             @RequestParam String features,
             @RequestParam(name = "rollbackOnFailure", required = false, defaultValue = "false")
@@ -313,13 +342,19 @@ public class FeatureLayerController extends AbstractGSRController {
             throws IOException, ServiceException {
         FeatureArray featureArray = jsonStringToFeatureArray(features);
         return addFeatures(
-                featureArray, workspaceName, layerId, rollbackOnFailure, returnEditMoment);
+                featureArray,
+                workspaceName,
+                layerName,
+                layerId,
+                rollbackOnFailure,
+                returnEditMoment);
     }
 
     /** @See FeatureLayerController#addFeaturesPost */
     private EditResults addFeatures(
             FeatureArray featureArray,
             String workspaceName,
+            String layerName,
             Integer layerId,
             boolean rollbackOnFailure,
             boolean returnEditMoment)
@@ -329,7 +364,7 @@ public class FeatureLayerController extends AbstractGSRController {
             throw new IllegalArgumentException("No features provided");
         }
 
-        LayerInfo layer = featureGet(workspaceName, layerId).layer;
+        LayerInfo layer = featureGet(workspaceName, layerName, layerId).layer;
 
         if (layer.getResource() instanceof FeatureTypeInfo) {
             FeatureTypeInfo fti = (FeatureTypeInfo) layer.getResource();
@@ -368,6 +403,7 @@ public class FeatureLayerController extends AbstractGSRController {
             name = "FeatureServesApplyEdits")
     public EditResults applyEditsByLayer(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable Integer layerId,
             @RequestParam(name = "adds", required = false) String adds,
             @RequestParam(name = "updates", required = false) String updates,
@@ -389,6 +425,7 @@ public class FeatureLayerController extends AbstractGSRController {
                         addFeatures(
                                 addsArray,
                                 workspaceName,
+                                layerName,
                                 layerId,
                                 returnEditMoment,
                                 rollbackOnFailure);
@@ -404,6 +441,7 @@ public class FeatureLayerController extends AbstractGSRController {
                         updateFeatures(
                                 updatesArray,
                                 workspaceName,
+                                layerName,
                                 layerId,
                                 returnEditMoment,
                                 rollbackOnFailure);
@@ -413,7 +451,12 @@ public class FeatureLayerController extends AbstractGSRController {
         if (deletes != null && deletes.length() > 0) {
             deleteEditResults =
                     deleteFeatures(
-                            workspaceName, layerId, deletes, returnEditMoment, rollbackOnFailure);
+                            workspaceName,
+                            layerName,
+                            layerId,
+                            deletes,
+                            returnEditMoment,
+                            rollbackOnFailure);
         }
 
         return new EditResults(
@@ -488,6 +531,7 @@ public class FeatureLayerController extends AbstractGSRController {
             name = "FeatureServerApplyEdits")
     public List<EditResults> applyEditsByService(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @RequestParam String edits,
             @RequestParam(name = "rollbackOnFailure", required = false, defaultValue = "false")
                     boolean rollbackOnFailure,
@@ -517,6 +561,7 @@ public class FeatureLayerController extends AbstractGSRController {
                             addFeatures(
                                     layerEdits.getAdds(),
                                     workspaceName,
+                                    layerName,
                                     layerEdits.getId(),
                                     returnEditMoment,
                                     rollbackOnFailure);
@@ -529,6 +574,7 @@ public class FeatureLayerController extends AbstractGSRController {
                             updateFeatures(
                                     layerEdits.getUpdates(),
                                     workspaceName,
+                                    layerName,
                                     layerEdits.getId(),
                                     returnEditMoment,
                                     rollbackOnFailure);
@@ -542,6 +588,7 @@ public class FeatureLayerController extends AbstractGSRController {
                     deleteEditResults =
                             deleteFeatures(
                                     workspaceName,
+                                    layerName,
                                     layerEdits.getId(),
                                     objectIdString,
                                     returnEditMoment,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerListController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerListController.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.gsr.api.feature;
 
+import java.io.IOException;
 import java.util.Arrays;
 import org.geoserver.config.GeoServer;
 import org.geoserver.gsr.api.AbstractGSRController;
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller for the Feature Service layers list endpoint */
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName}/FeatureServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/FeatureServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class FeatureLayerListController extends AbstractGSRController {
 
@@ -33,17 +34,24 @@ public class FeatureLayerListController extends AbstractGSRController {
 
     @GetMapping(path = "/layers", name = "FeatureServerGetLayers")
     @HTMLResponseBody(templateName = "featurelayers.ftl", fileName = "featurelayers.html")
-    public LayersAndTables getLayers(@PathVariable String workspaceName) {
-        LayersAndTables layers = LayerDAO.find(catalog, workspaceName);
+    public LayersAndTables getLayers(
+            @PathVariable String workspaceName, @PathVariable String layerName) throws IOException {
+        LayersAndTables layers = LayerDAO.find(catalog, workspaceName, layerName);
         layers.getPath()
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "FeatureServer", "FeatureServer")));
+                                new Link(workspaceName + "/" + layerName, layerName),
+                                new Link(
+                                        workspaceName + "/" + layerName + "/FeatureServer",
+                                        "FeatureServer")));
         layers.getInterfaces()
                 .add(
                         new Link(
-                                workspaceName + "/" + "FeatureServer/layers?f=json&pretty=true",
+                                workspaceName
+                                        + "/"
+                                        + layerName
+                                        + "/FeatureServer/layers?f=json&pretty=true",
                                 "REST"));
         return layers;
     }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -39,11 +39,11 @@ import org.springframework.web.bind.annotation.RestController;
 @APIService(
         service = "Feature",
         version = "1.0",
-        landingPage = "/gsr/rest/services",
+        landingPage = "gsr/rest/services",
         serviceClass = WFSInfo.class)
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName:.*}/FeatureServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/FeatureServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class FeatureServiceController extends QueryController {
 
@@ -54,7 +54,8 @@ public class FeatureServiceController extends QueryController {
 
     @GetMapping
     @HTMLResponseBody(templateName = "feature.ftl", fileName = "feature.html")
-    public FeatureServiceRoot featureServiceGet(@PathVariable String workspaceName) {
+    public FeatureServiceRoot featureServiceGet(
+            @PathVariable String workspaceName, @PathVariable String layerName) {
 
         WorkspaceInfo workspace = geoServer.getCatalog().getWorkspaceByName(workspaceName);
         if (workspace == null) {
@@ -66,29 +67,41 @@ public class FeatureServiceController extends QueryController {
             service = geoServer.getService(WFSInfo.class);
         }
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
-        for (LayerInfo l : geoServer.getCatalog().getLayers()) {
-            if (l.getType() == PublishedType.VECTOR
-                    && l.getResource().getStore().getWorkspace().equals(workspace)) {
-                layersInWorkspace.add(l);
-            }
+        LayerInfo l = geoServer.getCatalog().getLayerByName(layerName);
+        if (l.getType() == PublishedType.VECTOR
+                && l.getResource().getStore().getWorkspace().equals(workspace)) {
+            layersInWorkspace.add(l);
         }
         layersInWorkspace.sort(LayerNameComparator.INSTANCE);
         FeatureServiceRoot root =
                 new FeatureServiceRoot(
-                        service, workspaceName, Collections.unmodifiableList(layersInWorkspace));
+                        service,
+                        workspaceName + "/" + layerName,
+                        Collections.unmodifiableList(layersInWorkspace));
         root.getPath()
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "FeatureServer", "FeatureServer")));
+                                new Link(workspaceName + "/" + layerName, layerName),
+                                new Link(
+                                        workspaceName + "/" + layerName + "/" + "FeatureServer",
+                                        "FeatureServer")));
         root.getInterfaces()
-                .add(new Link(workspaceName + "/" + "FeatureServer?f=json&pretty=true", "REST"));
+                .add(
+                        new Link(
+                                workspaceName
+                                        + "/"
+                                        + layerName
+                                        + "/"
+                                        + "FeatureServer?f=json&pretty=true",
+                                "REST"));
         return root;
     }
 
-    @GetMapping(path = {"/query"})
+    @GetMapping(path = "/query")
     public FeatureServiceQueryResult query(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @RequestParam(name = "geometryType", required = false) String geometryTypeName,
             @RequestParam(name = "geometry", required = false) String geometryText,
             @RequestParam(name = "inSR", required = false) String inSRText,
@@ -108,7 +121,7 @@ public class FeatureServiceController extends QueryController {
             @RequestParam(name = "returnIdsOnly", required = false, defaultValue = "false")
                     boolean returnIdsOnly)
             throws IOException {
-        LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName);
+        LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName, layerName);
 
         FeatureServiceQueryResult queryResult = new FeatureServiceQueryResult(layersAndTables);
 

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/ExportMapController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/ExportMapController.java
@@ -40,10 +40,13 @@ public class ExportMapController extends AbstractGSRController {
 
     @GetMapping(
             produces = "application/json",
-            path = "/gsr/rest/services/{workspaceName}/MapServer/export",
+            path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer/export",
             name = "MapServerExportMap")
     @ResponseBody
-    public ExportMap exportMap(@PathVariable String workspaceName, HttpServletRequest request) {
+    public ExportMap exportMap(
+            @PathVariable String workspaceName,
+            @PathVariable String layerName,
+            HttpServletRequest request) {
         String requestURL = request.getRequestURL().toString();
         String requestParameters = request.getQueryString();
         String updatedRequestParameters =
@@ -53,26 +56,29 @@ public class ExportMapController extends AbstractGSRController {
     }
 
     @GetMapping(
-            path = "/gsr/rest/services/{workspaceName}/MapServer/export",
+            path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer/export",
             name = "MapServerExportMapImage")
     public void exportMap(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             HttpServletRequest request,
             HttpServletResponse response)
             throws Exception {
-        this.exportMapImage(workspaceName, request, response);
+        this.exportMapImage(workspaceName, layerName, request, response);
     }
 
     @GetMapping(
-            path = "/gsr/rest/services/{workspaceName}/MapServer/{layerId}/export",
+            path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer/{layerId}/export",
             name = "MapServerExportLayerMap")
     public void exportMapOfLayer(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable String layerId,
             HttpServletRequest request,
             HttpServletResponse response)
             throws Exception {
-        this.exportMapImageForLayers(workspaceName, request, response, "show:" + layerId);
+        this.exportMapImageForLayers(
+                workspaceName, layerName, request, response, "show:" + layerName);
     }
 
     /**
@@ -86,18 +92,22 @@ public class ExportMapController extends AbstractGSRController {
      * @throws Exception when an exception occurs
      */
     private void exportMapImage(
-            String workspaceName, HttpServletRequest request, HttpServletResponse response)
+            String workspaceName,
+            String layerName,
+            HttpServletRequest request,
+            HttpServletResponse response)
             throws Exception {
 
         String layers = request.getParameter("layers");
         if (layers == null) {
-            layers = getAllLayersInEsriFormat(workspaceName);
+            layers = getAllLayersInEsriFormat(workspaceName, layerName);
         }
-        exportMapImageForLayers(workspaceName, request, response, layers);
+        exportMapImageForLayers(workspaceName, layerName, request, response, layers);
     }
 
     private void exportMapImageForLayers(
             String workspaceName,
+            String layerName,
             HttpServletRequest request,
             HttpServletResponse response,
             String layers)
@@ -108,10 +118,11 @@ public class ExportMapController extends AbstractGSRController {
         MutableRequestProxy requestProxy = new MutableRequestProxy(request);
         requestProxy.getMutableParams().put("service", new String[] {"WMS"});
         requestProxy.getMutableParams().put("request", new String[] {"GetMap"});
-
         requestProxy
                 .getMutableParams()
-                .put("layers", new String[] {translateLayersParam(layers, workspaceName)});
+                .put(
+                        "layers",
+                        new String[] {translateLayersParam(layers, workspaceName, layerName)});
 
         String format = parameterMap.getOrDefault("format", parameterMap.get("FORMAT"))[0];
         requestProxy.getMutableParams().put("format", translateImageFormatParam(format));
@@ -177,7 +188,7 @@ public class ExportMapController extends AbstractGSRController {
         return new String[] {"image/" + formatFixed};
     }
 
-    private String translateLayersParam(String layers, String workspaceName) {
+    private String translateLayersParam(String layers, String workspaceName, String layerName) {
         if (StringUtils.isNotEmpty(layers)) {
             String[] layersSpecAndLayers = layers.split(":");
             if (layersSpecAndLayers.length < 2) {
@@ -197,25 +208,19 @@ public class ExportMapController extends AbstractGSRController {
             // catalogs
             return Arrays.stream(layersSpecAndLayers[1].split(","))
                     .map(
-                            layerName ->
+                            layerId ->
                                     LayersAndTables.integerIdToGeoserverLayerName(
-                                            catalog, layerName, workspaceName))
+                                            catalog, layerName, workspaceName, layerId))
                     .collect(Collectors.joining(","));
         } else {
             return null;
         }
     }
 
-    private String getAllLayersInEsriFormat(String workspaceName) {
+    private String getAllLayersInEsriFormat(String workspaceName, String layerName) {
         return "show:"
                 + catalog.getLayers().stream()
-                        .filter(
-                                li ->
-                                        li.getResource()
-                                                .getStore()
-                                                .getWorkspace()
-                                                .getName()
-                                                .equals(workspaceName))
+                        .filter(li -> li.getName().equals(layerName))
                         .map(LayerInfo::getName)
                         .collect(Collectors.joining(","));
     }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/GenerateKMLController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/GenerateKMLController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
         landingPage = "/gsr/rest/services",
         serviceClass = WMSInfo.class)
 @RestController
-@RequestMapping(path = "/gsr/rest/services/{workspaceName}/MapServer/generateKml")
+@RequestMapping(path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer/generateKml")
 public class GenerateKMLController {
 
     @Autowired private Dispatcher dispatcher;

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/LayerListController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/LayerListController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller for the Map Service layers list endpoint */
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName}/MapServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class LayerListController extends AbstractGSRController {
 
@@ -38,15 +38,26 @@ public class LayerListController extends AbstractGSRController {
 
     @GetMapping(path = "/layers", name = "MapServerGetLayers")
     @HTMLResponseBody(templateName = "maplayers.ftl", fileName = "maplayers.html")
-    public LayersAndTables getLayers(@PathVariable String workspaceName) {
-        LayersAndTables layers = LayerDAO.find(catalog, workspaceName);
+    public LayersAndTables getLayers(
+            @PathVariable String workspaceName, @PathVariable String layerName) {
+        LayersAndTables layers = LayerDAO.find(catalog, workspaceName, layerName);
         layers.getPath()
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "MapServer", "MapServer")));
+                                new Link(workspaceName + "/" + layerName, layerName),
+                                new Link(
+                                        workspaceName + "/" + layerName + "/" + "MapServer",
+                                        "MapServer")));
         layers.getInterfaces()
-                .add(new Link(workspaceName + "/" + "MapServer/layers?f=json&pretty=true", "REST"));
+                .add(
+                        new Link(
+                                workspaceName
+                                        + "/"
+                                        + layerName
+                                        + "/"
+                                        + "MapServer/layers?f=json&pretty=true",
+                                "REST"));
         return layers;
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedType;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.gsr.api.AbstractGSRController;
@@ -52,7 +53,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller for the root Map Service endpoint */
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName}/MapServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class MapServiceController extends AbstractGSRController {
 
@@ -66,7 +67,8 @@ public class MapServiceController extends AbstractGSRController {
 
     @GetMapping(name = "MapServerGetService")
     @HTMLResponseBody(templateName = "map.ftl", fileName = "map.html")
-    public MapServiceRoot mapServiceGet(@PathVariable String workspaceName) throws IOException {
+    public MapServiceRoot mapServiceGet(
+            @PathVariable String workspaceName, @PathVariable String layerName) throws IOException {
         WorkspaceInfo workspace = geoServer.getCatalog().getWorkspaceByName(workspaceName);
         if (workspace == null) {
             throw new NoSuchElementException(
@@ -77,22 +79,34 @@ public class MapServiceController extends AbstractGSRController {
             service = geoServer.getService(WMSInfo.class);
         }
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
-        for (LayerInfo l : geoServer.getCatalog().getLayers()) {
-            if (workspace.equals(l.getResource().getStore().getWorkspace())) {
-                layersInWorkspace.add(l);
-            }
+        LayerInfo l = geoServer.getCatalog().getLayerByName(layerName);
+        if (l.getType() == PublishedType.VECTOR
+                && l.getResource().getStore().getWorkspace().equals(workspace)) {
+            layersInWorkspace.add(l);
         }
         layersInWorkspace.sort(LayerNameComparator.INSTANCE);
         MapServiceRoot root =
                 new MapServiceRoot(
-                        service, workspaceName, Collections.unmodifiableList(layersInWorkspace));
+                        service,
+                        workspaceName + "/" + layerName,
+                        Collections.unmodifiableList(layersInWorkspace));
         root.getPath()
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "MapServer", "MapServer")));
+                                new Link(workspaceName + "/" + layerName, layerName),
+                                new Link(
+                                        workspaceName + "/" + layerName + "/" + "MapServer",
+                                        "MapServer")));
         root.getInterfaces()
-                .add(new Link(workspaceName + "/" + "MapServer?f=json&pretty=true", "REST"));
+                .add(
+                        new Link(
+                                workspaceName
+                                        + "/"
+                                        + layerName
+                                        + "/"
+                                        + "MapServer?f=json&pretty=true",
+                                "REST"));
         return root;
     }
 
@@ -100,21 +114,37 @@ public class MapServiceController extends AbstractGSRController {
             path = {"/{layerId}"},
             name = "MapServerGetLayer")
     @HTMLResponseBody(templateName = "maplayer.ftl", fileName = "maplayer.html")
-    public LayerOrTable getLayer(@PathVariable String workspaceName, @PathVariable Integer layerId)
+    public LayerOrTable getLayer(
+            @PathVariable String workspaceName,
+            @PathVariable String layerName,
+            @PathVariable Integer layerId)
             throws IOException {
-        LayerOrTable layer = LayerDAO.find(catalog, workspaceName, layerId);
+        LayerOrTable layer = LayerDAO.find(catalog, workspaceName, layerName, layerId);
         layer.getPath()
                 .addAll(
                         Arrays.asList(
                                 new Link(workspaceName, workspaceName),
-                                new Link(workspaceName + "/" + "MapServer", "MapServer"),
+                                new Link(workspaceName + "/" + layerName, layerName),
                                 new Link(
-                                        workspaceName + "/" + "MapServer/" + layerId,
+                                        workspaceName + "/" + layerName + "/" + "MapServer",
+                                        "MapServer"),
+                                new Link(
+                                        workspaceName
+                                                + "/"
+                                                + layerName
+                                                + "/"
+                                                + "MapServer/"
+                                                + layerId,
                                         layerId + "")));
         layer.getInterfaces()
                 .add(
                         new Link(
-                                workspaceName + "/MapServer/" + layerId + "?f=json&pretty=true",
+                                workspaceName
+                                        + "/"
+                                        + layerName
+                                        + "/MapServer/"
+                                        + layerId
+                                        + "?f=json&pretty=true",
                                 "REST"));
         return layer;
     }
@@ -122,6 +152,7 @@ public class MapServiceController extends AbstractGSRController {
     @GetMapping(path = "/identify", name = "MapServerIdentify")
     public IdentifyServiceResult identify(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @RequestParam(
                             name = "geometryType",
                             required = false,
@@ -133,7 +164,7 @@ public class MapServiceController extends AbstractGSRController {
 
         IdentifyServiceResult result = new IdentifyServiceResult();
 
-        LayerDAO.find(catalog, workspaceName)
+        LayerDAO.find(catalog, workspaceName, layerName)
                 .layers
                 .forEach(
                         layer -> {
@@ -174,6 +205,7 @@ public class MapServiceController extends AbstractGSRController {
     @GetMapping(path = "/find", name = "MapServerFind")
     public IdentifyServiceResult search(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @RequestParam String searchText,
             @RequestParam(required = false, defaultValue = "true") boolean contains,
             @RequestParam(required = false) String searchField,
@@ -190,7 +222,8 @@ public class MapServiceController extends AbstractGSRController {
         for (String s : layers.split(",")) {
             Integer layerId = Integer.parseInt(s);
             try {
-                LayerOrTable layerOrTable = LayerDAO.find(catalog, workspaceName, layerId);
+                LayerOrTable layerOrTable =
+                        LayerDAO.find(catalog, workspaceName, layerName, layerId);
                 if (layerOrTable != null && layerOrTable.layer != null) {
                     FeatureTypeInfo featureTypeInfo =
                             (FeatureTypeInfo) layerOrTable.layer.getResource();

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller for the Map Service query endpoint */
 @RestController
 @RequestMapping(
-        path = "/gsr/rest/services/{workspaceName}/MapServer",
+        path = "/gsr/rest/services/{workspaceName}/{layerName}/MapServer",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class QueryController extends AbstractGSRController {
 
@@ -45,6 +45,7 @@ public class QueryController extends AbstractGSRController {
     @GetMapping(path = "/{layerId}/query", name = "MapServerQuery")
     public GSRModel query(
             @PathVariable String workspaceName,
+            @PathVariable String layerName,
             @PathVariable Integer layerId,
             @RequestParam(
                             name = "geometryType",
@@ -78,7 +79,7 @@ public class QueryController extends AbstractGSRController {
                     String quantizationParameters)
             throws IOException {
 
-        LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName);
+        LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName, layerName);
 
         FeatureCollection<? extends FeatureType, ? extends Feature> features =
                 FeatureDAO.getFeatureCollectionForLayerWithId(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureServiceRoot.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureServiceRoot.java
@@ -39,7 +39,7 @@ public class FeatureServiceRoot extends AbstractGSRModel implements GSRModel {
         serviceDescription = service.getTitle() != null ? service.getTitle() : service.getName();
         for (int i = 0; i < layers.size(); i++) {
             LayerInfo l = layers.get(i);
-            this.layers.add(new LayerEntry(i, l.getName()));
+            this.layers.add(new LayerEntry(i, l.getTitle()));
         }
     }
 

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/map/LayersAndTables.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/map/LayersAndTables.java
@@ -51,11 +51,11 @@ public class LayersAndTables extends AbstractGSRModel implements GSRModel {
      * @return
      */
     public static String integerIdToGeoserverLayerName(
-            Catalog catalog, String layerName, String workspaceName) {
+            Catalog catalog, String layerName, String workspaceName, String layerId) {
         String name = layerName;
         try {
             LayerOrTable layerOrTable =
-                    LayerDAO.find(catalog, workspaceName, Integer.parseInt(layerName));
+                    LayerDAO.find(catalog, workspaceName, layerName, Integer.parseInt(layerName));
             name = layerOrTable.getName();
         } catch (IOException e) {
             throw new IllegalArgumentException(e);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/service/GeometryService.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/service/GeometryService.java
@@ -10,6 +10,9 @@
 package org.geoserver.gsr.model.service;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.geoserver.platform.GeoServerExtensions;
 
 /**
  * Simple model of a geometry service, for use in the list of services published by {@link
@@ -23,6 +26,13 @@ public class GeometryService implements AbstractService {
     private String name;
 
     private ServiceType type;
+
+    /*
+     * The key of the property to disable the GeometryServer. This property is set default to false.
+     */
+    public static final String DISABLE_GSR_GEOMETRY_SERVICE_KEY = "DISABLE_GSR_GEOMETRY_SERVICE";
+
+    private static boolean geometryServiceDisabled = isGeometryServicePropertyDisabled();
 
     public String getName() {
         return name;
@@ -43,5 +53,25 @@ public class GeometryService implements AbstractService {
     public GeometryService(String name) {
         this.name = name;
         this.type = ServiceType.GeometryServer;
+    }
+
+    private static boolean isGeometryServicePropertyDisabled() {
+        String geometryService = GeoServerExtensions.getProperty(DISABLE_GSR_GEOMETRY_SERVICE_KEY);
+        return Boolean.parseBoolean(geometryService);
+    }
+
+    private static ReadWriteLock lock = new ReentrantReadWriteLock(true);
+
+    /**
+     * @return The boolean returned represents the value of the geometryService disable toggle (if
+     *     true geometryService is disabled)
+     */
+    public static boolean isGeometryServiceDisabled() {
+        lock.readLock().lock();
+        try {
+            return geometryServiceDisabled;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/map/LayerDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/map/LayerDAO.java
@@ -29,20 +29,20 @@ public class LayerDAO {
      *
      * @param catalog GeoServer Catalog
      * @param workspaceName GeoServer workspace name
-     * @param id Index of Layer (based on sorting by layer name)
+     * @param layerName Index of Layer (based on sorting by layer name)
      * @return LayerOrTable from workspaceName identified by layerId
      * @throws IOException
      */
-    public static LayerOrTable find(Catalog catalog, String workspaceName, Integer id)
+    public static LayerOrTable find(
+            Catalog catalog, String workspaceName, String layerName, Integer id)
             throws IOException {
         // short list all layers
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
-        for (LayerInfo l : catalog.getLayers()) {
-            if (l.enabled()
-                    && l.getType() == PublishedType.VECTOR
-                    && l.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
-                layersInWorkspace.add(l);
-            }
+        LayerInfo l = catalog.getLayerByName(layerName);
+        if (l.enabled()
+                && l.getType() == PublishedType.VECTOR
+                && l.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
+            layersInWorkspace.add(l);
         }
         // sort for "consistent" order
         layersInWorkspace.sort(LayerNameComparator.INSTANCE);
@@ -81,17 +81,16 @@ public class LayerDAO {
      * @return GeoServer Layers gathered into GSR layers (with at least one geometry column) or
      *     tables.
      */
-    public static LayersAndTables find(Catalog catalog, String workspaceName) {
+    public static LayersAndTables find(Catalog catalog, String workspaceName, String layerName) {
         List<LayerOrTable> layers = new ArrayList<>();
         List<LayerOrTable> tables = new ArrayList<>();
         int idCounter = 0;
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
-        for (LayerInfo l : catalog.getLayers()) {
-            if (l.enabled()
-                    && l.getType() == PublishedType.VECTOR
-                    && l.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
-                layersInWorkspace.add(l);
-            }
+        LayerInfo li = catalog.getLayerByName(layerName);
+        if (li.enabled()
+                && li.getType() == PublishedType.VECTOR
+                && li.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
+            layersInWorkspace.add(li);
         }
         layersInWorkspace.sort(LayerNameComparator.INSTANCE);
         for (LayerInfo l : layersInWorkspace) {

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/QGISIntegrationTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/QGISIntegrationTest.java
@@ -23,7 +23,8 @@ public class QGISIntegrationTest extends ControllerTest {
     @Test
     public void testListFeatureLayers() throws Exception {
         // Get root
-        JSONObject result = (JSONObject) getAsJSON(getBaseURL() + "cite/FeatureServer?f=json");
+        JSONObject result =
+                (JSONObject) getAsJSON(getBaseURL() + "cite/Buildings/FeatureServer?f=json");
         assertFalse(result.has("error"));
         List<String> ids = new ArrayList<>();
 
@@ -33,7 +34,13 @@ public class QGISIntegrationTest extends ControllerTest {
         }
         // Get each layer by id
         for (String id : ids) {
-            result = (JSONObject) getAsJSON(getBaseURL() + "cite/FeatureServer/" + id + "?f=json");
+            result =
+                    (JSONObject)
+                            getAsJSON(
+                                    getBaseURL()
+                                            + "cite/Buildings/FeatureServer/"
+                                            + id
+                                            + "?f=json");
             assertFalse(result.has("error"));
             assertFalse(result.toString().isEmpty());
         }
@@ -42,7 +49,8 @@ public class QGISIntegrationTest extends ControllerTest {
     @Test
     public void testGetFeatureLayer() throws Exception {
         // get layer by id (cite:Buildings)
-        JSONObject result = (JSONObject) getAsJSON(getBaseURL() + "cite/FeatureServer/2?f=json");
+        JSONObject result =
+                (JSONObject) getAsJSON(getBaseURL() + "cite/Buildings/FeatureServer/0?f=json");
         assertFalse(result.has("error"));
         assertFalse(result.toString().isEmpty());
         // get ids
@@ -66,7 +74,7 @@ public class QGISIntegrationTest extends ControllerTest {
                 (JSONObject)
                         getAsJSON(
                                 getBaseURL()
-                                        + "cite/FeatureServer/2/query?f=json&where="
+                                        + "cite/Buildings/FeatureServer/0/query?f=json&where="
                                         + idField
                                         + "%3D"
                                         + idField
@@ -85,7 +93,7 @@ public class QGISIntegrationTest extends ControllerTest {
                 (JSONObject)
                         getAsJSON(
                                 getBaseURL()
-                                        + "cite/FeatureServer/2/query?f=json&objectIds="
+                                        + "cite/Buildings/FeatureServer/0/query?f=json&objectIds="
                                         + idString
                                         + "&outFields="
                                         + outFieldString

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/api/map/ExportMapControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/api/map/ExportMapControllerTest.java
@@ -15,7 +15,6 @@ import java.awt.image.RenderedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import javax.imageio.ImageIO;
-import net.sf.json.JSONObject;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.gsr.controller.ControllerTest;
 import org.geotools.image.test.ImageAssert;
@@ -31,7 +30,7 @@ public class ExportMapControllerTest extends ControllerTest {
         String exportMapUrl =
                 getBaseURL()
                         + SystemTestData.BASIC_POLYGONS.getPrefix()
-                        + "/MapServer/export?f=image&bbox=-180.0,-90.0,180.0,90.0&layers=show:"
+                        + "/BasicPolygons/MapServer/export?f=image&bbox=-180.0,-90.0,180.0,90.0&layers=show:"
                         + SystemTestData.BASIC_POLYGONS.getLocalPart()
                         + "&size=150,150&format=png";
         MockHttpServletResponse servletResponse = getAsServletResponse(exportMapUrl);
@@ -43,26 +42,10 @@ public class ExportMapControllerTest extends ControllerTest {
 
     @Test
     public void exportMapNumber() throws Exception {
-        JSONObject json =
-                (JSONObject)
-                        getAsJSON(
-                                getBaseURL()
-                                        + SystemTestData.BASIC_POLYGONS.getPrefix()
-                                        + "/MapServer");
-        print(json);
-        Integer basicPolygonsId =
-                (Integer)
-                        json.getJSONArray("layers").stream()
-                                .filter(o -> "BasicPolygons".equals(((JSONObject) o).get("name")))
-                                .map(o -> ((JSONObject) o).get("id"))
-                                .findFirst()
-                                .get();
-
         String exportMapUrl =
                 getBaseURL()
                         + SystemTestData.BASIC_POLYGONS.getPrefix()
-                        + "/MapServer/export?f=image&bbox=-180.0,-90.0,180.0,90.0&layers=show:"
-                        + basicPolygonsId
+                        + "/BasicPolygons/MapServer/export?f=image&bbox=-180.0,-90.0,180.0,90.0&layers=show:0"
                         + "&size=150,150&format=png";
         MockHttpServletResponse servletResponse = getAsServletResponse(exportMapUrl);
         RenderedImage image =
@@ -76,7 +59,7 @@ public class ExportMapControllerTest extends ControllerTest {
         String exportMapUrl =
                 getBaseURL()
                         + SystemTestData.BASIC_POLYGONS.getPrefix()
-                        + "/MapServer/0/export?f=image&bbox=-180.0,-90.0,180.0,90.0&layers&size=150,150&format=png";
+                        + "/BasicPolygons/MapServer/0/export?f=image&bbox=-180.0,-90.0,180.0,90.0&layers&size=150,150&format=png";
         MockHttpServletResponse servletResponse = getAsServletResponse(exportMapUrl);
         System.out.println(servletResponse.getErrorMessage());
         assertTrue(
@@ -93,7 +76,7 @@ public class ExportMapControllerTest extends ControllerTest {
         String exportMapUrl =
                 getBaseURL()
                         + SystemTestData.BASIC_POLYGONS.getPrefix()
-                        + "/MapServer/export?f=json&bbox=-180.0,-90.0,180.0,90.0&layers=show:"
+                        + "/BasicPolygons/MapServer/export?f=json&bbox=-180.0,-90.0,180.0,90.0&layers=show:"
                         + SystemTestData.BASIC_POLYGONS.getLocalPart()
                         + "&size=150,150";
 

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/api/map/GenerateKMLControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/api/map/GenerateKMLControllerTest.java
@@ -26,7 +26,7 @@ public class GenerateKMLControllerTest extends WMSTestSupport {
         String exportMapUrl =
                 "/gsr/rest/services/"
                         + SystemTestData.BASIC_POLYGONS.getPrefix()
-                        + "/MapServer/generateKml?layers="
+                        + "/BasicPolygons/MapServer/generateKml?layers="
                         + SystemTestData.BASIC_POLYGONS.getLocalPart();
 
         String layerName = SystemTestData.BASIC_POLYGONS.getLocalPart();

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/CatalogServiceControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/CatalogServiceControllerTest.java
@@ -48,12 +48,26 @@ public class CatalogServiceControllerTest extends ControllerTest {
         JSON json = getAsJSON(getBaseURL() + "?f=json");
         assertTrue(json instanceof JSONObject);
         JSONObject jsonObject = (JSONObject) json;
+        JSONArray workspaces = (JSONArray) jsonObject.get("folders");
+        String workspace = workspaces.getString(3);
+        assertEquals("cite", workspace);
+
+        json = getAsJSON(getBaseURL() + "/cite?f=json");
+        assertTrue(json instanceof JSONObject);
+        jsonObject = (JSONObject) json;
+        JSONArray layers = (JSONArray) jsonObject.get("folders");
+        String layer = layers.getString(0);
+        assertEquals("cite/BasicPolygons", layer);
+
+        json = getAsJSON(getBaseURL() + "/cite/BasicPolygons?f=json");
+        assertTrue(json instanceof JSONObject);
+        jsonObject = (JSONObject) json;
         JSONArray services = (JSONArray) jsonObject.get("services");
         JSONObject mapService = services.getJSONObject(0);
-        assertEquals("LocalWorkspace", mapService.get("name"));
+        assertEquals("cite/BasicPolygons", mapService.get("name"));
         assertEquals("MapServer", mapService.get("type"));
         JSONObject featureService = services.getJSONObject(1);
-        assertEquals("LocalWorkspace", featureService.get("name"));
+        assertEquals("cite/BasicPolygons", featureService.get("name"));
         assertEquals("FeatureServer", featureService.get("type"));
         JSONObject geometryService = services.getJSONObject(services.size() - 1);
         assertEquals("Geometry", geometryService.get("name"));

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/ServiceTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/ServiceTest.java
@@ -35,6 +35,7 @@ public class ServiceTest extends GeoServerSystemTestSupport {
                 service.getOperations(),
                 Matchers.containsInAnyOrder(
                         "FeatureServerGetLayers",
+                        "FeatureServerGetLegend",
                         "FeatureServerAddFeatures",
                         "FeatureServerApplyEdits",
                         "FeatureServerDeleteFeatures",
@@ -42,6 +43,8 @@ public class ServiceTest extends GeoServerSystemTestSupport {
                         "FeatureServerUpdateFeatures",
                         "FeatureServesApplyEdits",
                         "GetServices",
+                        "GetLayerFolders",
+                        "GetWorkspaceFolders",
                         "MapServerExportMap",
                         "MapServerExportMapImage",
                         "MapServerFind",

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureControllerTest.java
@@ -20,19 +20,19 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 public class FeatureControllerTest extends ControllerTest {
     private String query(String service, String layer, String feature, String params) {
-        return getBaseURL() + service + "/FeatureServer/" + layer + "/" + feature + params;
+        return getBaseURL() + service + "/Bridges/FeatureServer/" + layer + "/" + feature + params;
     }
 
     @Test
     public void testBasicQuery() throws Exception {
-        String q = query("cite", "1", "1107531599613", "?f=json");
+        String q = query("cite", "0", "1107531599613", "?f=json");
         JSON result = getAsJSON(q);
         checkResult(result);
     }
 
     @Test
     public void testBasicQueryPJson() throws Exception {
-        String q = query("cite", "1", "1107531599613", "?f=pjson");
+        String q = query("cite", "0", "1107531599613", "?f=pjson");
         MockHttpServletResponse response = getAsServletResponse(q);
         assertEquals(response.getContentType(), "application/json");
         JSON result = json(response);

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureLayerControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureLayerControllerTest.java
@@ -84,12 +84,12 @@ public class FeatureLayerControllerTest extends ControllerTest {
         }
     }
 
-    private String query(String service, String layer, String params) {
-        return getBaseURL() + service + "/FeatureServer/" + layer + params;
+    private String query(String service, String layerName, String layer, String params) {
+        return getBaseURL() + service + "/" + layerName + "/FeatureServer/" + layer + params;
     }
 
-    private String serviceQuery(String service, String params) {
-        return getBaseURL() + service + "/FeatureServer" + params;
+    private String serviceQuery(String service, String layerName, String params) {
+        return getBaseURL() + service + "/" + layerName + "/FeatureServer" + params;
     }
 
     @Before
@@ -105,7 +105,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
 
     @Test
     public void testBasicQuery() throws Exception {
-        String q = query("cite", "1", "?f=json");
+        String q = query("cite", "BasicPolygons", "0", "?f=json");
         JSON result = getAsJSON(q);
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
 
@@ -132,7 +132,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         assertTrue(Math.abs(nativeGeom.getGeometryN(0).getCoordinates()[0].x - 500050.0) >= 0.1);
         assertTrue(Math.abs(nativeGeom.getGeometryN(0).getCoordinates()[0].y - 499950.0) >= 0.1);
 
-        String q = query("cgf", "0", "/updateFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/updateFeatures?f=json");
 
         String body =
                 "[\n"
@@ -171,7 +171,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
 
     @Test
     public void testUpdateFeaturesErrors() throws Exception {
-        String q = query("cgf", "0", "/updateFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/updateFeatures?f=json");
 
         // no id
         String body =
@@ -263,7 +263,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         assertEquals(2, nativeGeom.getNumGeometries());
 
         // Get cgf:MPolygons, feature 0
-        String q = query("cgf", "2", "/0?f=json");
+        String q = query("cgf", "MPoints", "0", "/0?f=json");
         JSON result = getAsJSON(q);
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
 
@@ -276,7 +276,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         String body = featureArray.toString();
 
         // do POST
-        q = query("cgf", "2", "/updateFeatures?f=json");
+        q = query("cgf", "MPoints", "0", "/updateFeatures?f=json");
         result = postUpdatesAsForm(q, body, false, null);
 
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
@@ -321,7 +321,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         assertEquals(2, nativeGeom.getNumGeometries());
 
         // Get cgf:MPolygons, feature 0
-        String q = query("cgf", "1", "/0?f=json");
+        String q = query("cgf", "MLines", "0", "/0?f=json");
         JSON result = getAsJSON(q);
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
 
@@ -334,7 +334,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         String body = featureArray.toString();
 
         // do POST
-        q = query("cgf", "1", "/updateFeatures?f=json");
+        q = query("cgf", "MLines", "0", "/updateFeatures?f=json");
         result = postUpdatesAsForm(q, body, false, null);
 
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
@@ -380,7 +380,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         assertEquals(2, nativeGeom.getNumGeometries());
 
         // Get cgf:MPolygons, feature 0
-        String q = query("cgf", "3", "/0?f=json");
+        String q = query("cgf", "MPolygons", "0", "/0?f=json");
         JSON result = getAsJSON(q);
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
 
@@ -393,7 +393,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         String body = featureArray.toString();
 
         // do POST
-        q = query("cgf", "3", "/updateFeatures?f=json");
+        q = query("cgf", "MPolygons", "0", "/updateFeatures?f=json");
         result = postUpdatesAsForm(q, body, false, null);
 
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONObject);
@@ -433,7 +433,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         assertTrue(Math.abs(nativeGeom.getGeometryN(0).getCoordinates()[0].x - 500050.0) >= 0.1);
         assertTrue(Math.abs(nativeGeom.getGeometryN(0).getCoordinates()[0].y - 499950.0) >= 0.1);
 
-        String q = query("cgf", "0", "/addFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/addFeatures?f=json");
 
         String body =
                 "[\n"
@@ -472,7 +472,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
 
     @Test
     public void testAddFeaturesErrors() throws Exception {
-        String q = query("cgf", "0", "/addFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/addFeatures?f=json");
 
         // malformed geometry
         String body =
@@ -552,7 +552,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         // verify initial feature state
         assertEquals(1, fti.getFeatureSource(null, null).getFeatures().size());
 
-        String q = query("cgf", "0", "/addFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/addFeatures?f=json");
 
         // 3 features, one invalid
         String body =
@@ -619,7 +619,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         // verify initial feature state
         assertEquals(1, fti.getFeatureSource(null, null).getFeatures().size());
 
-        String q = query("cgf", "0", "/addFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/addFeatures?f=json");
 
         // 3 features, one invalid
         String body =
@@ -685,7 +685,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         // verify initial feature state
         assertEquals(1, fti.getFeatureSource(null, null).getFeatures().size());
 
-        String q = query("cgf", "0", "/deleteFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/deleteFeatures?f=json");
 
         // JSON result = postAsJSON(q, body, "application/json");
         JSON result = postDeletesAsForm(q, "0", null, null, null, null, null, null, false, false);
@@ -709,7 +709,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         // verify initial feature state
         assertEquals(1, fti.getFeatureSource(null, null).getFeatures().size());
 
-        String q = query("cgf", "0", "/deleteFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/deleteFeatures?f=json");
 
         // JSON result = postAsJSON(q, body, "application/json");
         JSON result =
@@ -745,7 +745,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         // verify initial feature state
         assertEquals(1, fti.getFeatureSource(null, null).getFeatures().size());
 
-        String q = query("cgf", "0", "/deleteFeatures?f=json");
+        String q = query("cgf", "Lines", "0", "/deleteFeatures?f=json");
 
         String body = "";
 
@@ -775,6 +775,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
         String q =
                 query(
                         "cgf",
+                        "Lines",
                         "0",
                         "/applyEdits?f=json&rollbackOnFailure=false&returnEditMoment=false");
 
@@ -853,15 +854,15 @@ public class FeatureLayerControllerTest extends ControllerTest {
         // Use 'cgf' workspace - 0 Lines, 1 MLines, 2 MPoints, 3 MPolygons, 4 Points, 5 Polygons,
         Catalog catalog = getCatalog();
         FeatureTypeInfo ftiLines = catalog.getFeatureTypeByName("cgf", "Lines");
-        FeatureTypeInfo ftiPoints = catalog.getFeatureTypeByName("cgf", "Points");
 
         // verify initial feature state
         assertEquals(1, ftiLines.getFeatureSource(null, null).getFeatures().size());
-        assertEquals(1, ftiPoints.getFeatureSource(null, null).getFeatures().size());
 
         String q =
                 serviceQuery(
-                        "cgf", "/applyEdits?f=json&rollbackOnFailure=false&returnEditMoment=false");
+                        "cgf",
+                        "Lines",
+                        "/applyEdits?f=json&rollbackOnFailure=false&returnEditMoment=false");
 
         String addsBodyLine =
                 "[\n"
@@ -904,52 +905,7 @@ public class FeatureLayerControllerTest extends ControllerTest {
                         + deletesBodyLine
                         + "}";
 
-        String addsBodyPoint =
-                "[\n"
-                        + "  {\n"
-                        + "  \"geometry\" : {"
-                        + "      \"geometryType\":\"esriGeometryPoint\", "
-                        + "      \"x\" : 50051, "
-                        + "      \"y\" : 50051, "
-                        + "      \"spatialReference\" : {\"wkid\" : 32615}"
-                        + "    },\n"
-                        + "    \"attributes\" : {\n"
-                        + "      \"id\" : \"t0002\",\n"
-                        + "      \"altitude\" : 400,\n"
-                        + "    }\n"
-                        + "  }\n"
-                        + "]";
-        String updatesBodyPoint =
-                "[\n"
-                        + "  {\n"
-                        + "  \"geometry\" : {"
-                        + "      \"geometryType\":\"esriGeometryPoint\", "
-                        + "      \"x\" : 50051, "
-                        + "      \"y\" : 50051, "
-                        + "      \"spatialReference\" : {\"wkid\" : 32615}"
-                        + "    },\n"
-                        + "    \"attributes\" : {\n"
-                        + "      \"objectid\" : 0,\n"
-                        + "      \"id\" : \"t0001\",\n"
-                        + "      \"altitude\" : 350,\n"
-                        + "    }\n"
-                        + "  }\n"
-                        + "]";
-        String deletesBodyPoint = "[0]";
-
-        String layerEdit4 =
-                "{\"id\":4,"
-                        + "\"adds\":"
-                        + addsBodyPoint
-                        + ","
-                        + "\"updates\":"
-                        + updatesBodyPoint
-                        + ","
-                        + "\"deletes\":"
-                        + deletesBodyPoint
-                        + "}";
-
-        String serviceEdits = "[" + layerEdit0 + "," + layerEdit4 + "]";
+        String serviceEdits = "[" + layerEdit0 + "]";
 
         JSON result = postServiceEditsAsForm(q, serviceEdits);
         assertTrue(String.valueOf(result) + " is a JSON object", result instanceof JSONArray);
@@ -994,48 +950,6 @@ public class FeatureLayerControllerTest extends ControllerTest {
         JSONObject resultLineUpdate =
                 resultLineLayer.getJSONArray("updateResults").getJSONObject(0);
         assertEquals(true, resultLineUpdate.getBoolean("success"));
-
-        JSONObject resultPointLayer = (JSONObject) json.get(1);
-        JSONObject resultPointDelete =
-                resultPointLayer.getJSONArray("deleteResults").getJSONObject(0);
-        assertEquals(true, resultPointDelete.getBoolean("success"));
-
-        // verify feature was deleted
-        assertEquals(1, ftiPoints.getFeatureSource(null, null).getFeatures().size());
-
-        assertNotSame(
-                "Points.0",
-                ftiLines.getFeatureSource(null, null)
-                        .getFeatures()
-                        .features()
-                        .next()
-                        .getIdentifier()
-                        .getID());
-
-        System.out.println(
-                ftiPoints
-                        .getFeatureSource(null, null)
-                        .getFeatures()
-                        .features()
-                        .next()
-                        .getProperty("id"));
-        // verify feature was added
-        JSONObject resultPointAdd = resultPointLayer.getJSONArray("addResults").getJSONObject(0);
-        assertEquals(true, resultPointAdd.getBoolean("success"));
-        assertEquals(
-                "t0002",
-                ftiPoints
-                        .getFeatureSource(null, null)
-                        .getFeatures()
-                        .features()
-                        .next()
-                        .getProperty("id")
-                        .getValue());
-
-        JSONObject resultPointUpdate =
-                resultPointLayer.getJSONArray("updateResults").getJSONObject(0);
-        assertEquals(true, resultPointUpdate.getBoolean("success"));
-
         System.out.println(json);
     }
 
@@ -1115,7 +1029,8 @@ public class FeatureLayerControllerTest extends ControllerTest {
 
     @Test
     public void testTriangle() throws Exception {
-        JSONObject json = (JSONObject) getAsJSON(query(TRIANGLES.getPrefix(), "1", ""));
+        JSONObject json =
+                (JSONObject) getAsJSON(query(TRIANGLES.getPrefix(), "Triangles", "0", ""));
         print(json);
         JSONObject renderer = json.getJSONObject("drawingInfo").getJSONObject("renderer");
         assertEquals("simple", renderer.getString("type"));
@@ -1127,13 +1042,13 @@ public class FeatureLayerControllerTest extends ControllerTest {
 
     @Test
     public void testTriangleHTML() throws Exception {
-        Document document = getAsJSoup(query(TRIANGLES.getPrefix(), "1", "?f=html"));
+        Document document = getAsJSoup(query(TRIANGLES.getPrefix(), "Triangles", "0", "?f=html"));
         // TODO: actually test contents, so far it's just a smoke test
     }
 
     @Test
     public void testDiamond() throws Exception {
-        JSONObject json = (JSONObject) getAsJSON(query(DIAMONDS.getPrefix(), "0", ""));
+        JSONObject json = (JSONObject) getAsJSON(query(DIAMONDS.getPrefix(), "Diamonds", "0", ""));
         print(json);
         JSONObject renderer = json.getJSONObject("drawingInfo").getJSONObject("renderer");
         assertEquals("simple", renderer.getString("type"));
@@ -1145,20 +1060,20 @@ public class FeatureLayerControllerTest extends ControllerTest {
 
     @Test
     public void testSimpleFillHTML() throws Exception {
-        Document document = getAsJSoup(query("cite", "2", "?f=html"));
+        Document document = getAsJSoup(query("cite", "Bridges", "0", "?f=html"));
         // TODO: actually test contents, so far it's just a smoke test
     }
 
     @Test
     public void testPictureMarkerHTML() throws Exception {
-        Document document = getAsJSoup(query(POI.getPrefix(), "2", "?f=html"));
+        Document document = getAsJSoup(query(POI.getPrefix(), "poi", "0", "?f=html"));
         // TODO: actually test contents, so far it's just a smoke test
     }
 
     @Test
     public void testSimpleLineHTML() throws Exception {
         // mlines
-        Document document = getAsJSoup(query("cgf", "1", "?f=html"));
+        Document document = getAsJSoup(query("cgf", "Lines", "0", "?f=html"));
         // TODO: actually test contents, so far it's just a smoke test
     }
 }

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureLayerListControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureLayerListControllerTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 public class FeatureLayerListControllerTest extends ControllerTest {
     private String query(String service, String params) {
-        return getBaseURL() + service + "/FeatureServer/layers";
+        return getBaseURL() + service + "/Lines/FeatureServer/layers";
     }
 
     @Test

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureServiceControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureServiceControllerTest.java
@@ -21,17 +21,17 @@ import org.geoserver.gsr.controller.ControllerTest;
 import org.junit.Test;
 
 public class FeatureServiceControllerTest extends ControllerTest {
-    private String query(String service, String params) {
-        return getBaseURL() + service + "/FeatureServer" + params;
+    private String query(String service, String layerName, String params) {
+        return getBaseURL() + service + "/" + layerName + "/FeatureServer" + params;
     }
 
     private String queryServiceUrl() {
-        return getBaseURL() + "cite" + "/FeatureServer/query" + "?f=json";
+        return getBaseURL() + "cite" + "/BasicPolygons/FeatureServer/query" + "?f=json";
     }
 
     @Test
     public void testBasicQuery() throws Exception {
-        String result = getAsString(query("cite", "?f=json"));
+        String result = getAsString(query("cite", "BasicPolygons", "?f=json"));
         assertFalse(result.isEmpty());
         System.out.println(result);
         // TODO: Can't validate since ids are not integers.
@@ -52,7 +52,12 @@ public class FeatureServiceControllerTest extends ControllerTest {
 
     @Test
     public void testQueryByObjectId() throws Exception {
-        JSON result = getAsJSON(query("cdf", "/3/query?f=json" + "&objectIds=0,1,2,3,4,5,6,7,8,9"));
+        JSON result =
+                getAsJSON(
+                        query(
+                                "cdf",
+                                "Locks",
+                                "/0/query?f=json" + "&objectIds=0,1,2,3,4,5,6,7,8,9"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -62,7 +67,7 @@ public class FeatureServiceControllerTest extends ControllerTest {
 
     @Test
     public void testQueryWhereObjectId() throws Exception {
-        JSON result = getAsJSON(query("cdf", "/3/query?f=json" + "&where=objectid=0"));
+        JSON result = getAsJSON(query("cdf", "Locks", "/0/query?f=json" + "&where=objectid=0"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -73,7 +78,11 @@ public class FeatureServiceControllerTest extends ControllerTest {
     @Test
     public void testQueryWhereOrObjectIds() throws Exception {
         JSON result =
-                getAsJSON(query("cdf", "/3/query?f=json" + "&where=objectid=0 or objectid=1"));
+                getAsJSON(
+                        query(
+                                "cdf",
+                                "Locks",
+                                "/0/query?f=json" + "&where=objectid=0 or objectid=1"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -84,7 +93,11 @@ public class FeatureServiceControllerTest extends ControllerTest {
     @Test
     public void testQueryWhereAndObjectIds() throws Exception {
         JSON result =
-                getAsJSON(query("cdf", "/3/query?f=json" + "&where=objectid=0 and objectid=1"));
+                getAsJSON(
+                        query(
+                                "cdf",
+                                "Locks",
+                                "/0/query?f=json" + "&where=objectid=0 and objectid=1"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -95,7 +108,11 @@ public class FeatureServiceControllerTest extends ControllerTest {
     @Test
     public void testQueryWhereInObjectIds() throws Exception {
         JSON result =
-                getAsJSON(query("cdf", "/3/query?f=json" + "&where=objectid IN ('0','1','2')"));
+                getAsJSON(
+                        query(
+                                "cdf",
+                                "Locks",
+                                "/0/query?f=json" + "&where=objectid IN ('0','1','2')"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -105,7 +122,8 @@ public class FeatureServiceControllerTest extends ControllerTest {
 
     @Test
     public void testQueryByWhere() throws Exception {
-        JSON result = getAsJSON(query("cdf", "/3/query?f=json&where=\"id\" LIKE ' lfbt%25'"));
+        JSON result =
+                getAsJSON(query("cdf", "Locks", "/0/query?f=json&where=\"id\" LIKE ' lfbt%25'"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -119,7 +137,8 @@ public class FeatureServiceControllerTest extends ControllerTest {
                 getAsJSON(
                         query(
                                 "cdf",
-                                "/3/query?f=json&where=\"id\" LIKE ' lfbt%25'"
+                                "Locks",
+                                "/0/query?f=json&where=\"id\" LIKE ' lfbt%25'"
                                         + "&objectIds=0,1,2,3,4,5,6,7,8,9"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
@@ -130,7 +149,7 @@ public class FeatureServiceControllerTest extends ControllerTest {
 
     @Test
     public void testFeaturesNative() throws Exception {
-        JSON result = getAsJSON(query("cdf", "/3/query?f=json" + "&objectIds=0"));
+        JSON result = getAsJSON(query("cdf", "Locks", "/0/query?f=json" + "&objectIds=0"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -146,7 +165,8 @@ public class FeatureServiceControllerTest extends ControllerTest {
 
     @Test
     public void testFeaturesReprojected() throws Exception {
-        JSON result = getAsJSON(query("cdf", "/3/query?f=json" + "&objectIds=0&outSR=102100"));
+        JSON result =
+                getAsJSON(query("cdf", "Locks", "/0/query?f=json" + "&objectIds=0&outSR=102100"));
         System.out.println(result.toString());
         JSONObject object = (JSONObject) result;
         assertFalse(object.has("error"));
@@ -166,7 +186,8 @@ public class FeatureServiceControllerTest extends ControllerTest {
                 getAsJSON(
                         query(
                                 "cdf",
-                                "/3/query?f=json&objectIds=0&outSR=102100"
+                                "Locks",
+                                "/0/query?f=json&objectIds=0&outSR=102100"
                                         + "&quantizationParameters={"
                                         + "\"mode\":\"view\","
                                         + "\"originPosition\":\"upperLeft\","

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/LayerListControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/LayerListControllerTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 public class LayerListControllerTest extends ControllerTest {
     private String query(String service, String params) {
-        return getBaseURL() + service + "/MapServer/layers" + params;
+        return getBaseURL() + service + "/Streams/MapServer/layers" + params;
     }
 
     @Test

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/MapServiceControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/MapServiceControllerTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 public class MapServiceControllerTest extends ControllerTest {
     private String query(String service, String params) {
-        return getBaseURL() + service + "/MapServer" + params;
+        return getBaseURL() + service + "/BasicPolygons/MapServer" + params;
     }
 
     @Test
@@ -43,7 +43,7 @@ public class MapServiceControllerTest extends ControllerTest {
 
     @Test
     public void testLayerGet() throws Exception {
-        JSONObject result = (JSONObject) getAsJSON(getBaseURL() + "cite/MapServer/0");
+        JSONObject result = (JSONObject) getAsJSON(getBaseURL() + "cite/BasicPolygons/MapServer/0");
         System.out.println(result.toString());
     }
 
@@ -53,8 +53,8 @@ public class MapServiceControllerTest extends ControllerTest {
                 (JSONObject)
                         getAsJSON(
                                 getBaseURL()
-                                        + "/cite/MapServer/identify?f=json"
-                                        + "&geometryType=esriGeometryPoint&geometry={x: 0, y: 0}"
+                                        + "/cite/BasicPolygons/MapServer/identify?f=json"
+                                        + "&geometryType=esriGeometryPoint&geometry={x: 0, y:0}"
                                         + "&layers=all:0&imageDisplay=718,610,96&mapExtent=-126.175461,11.400420,-65.525810,"
                                         + "62.927282&tolerance=10 ");
         System.out.println(result.toString());
@@ -63,7 +63,7 @@ public class MapServiceControllerTest extends ControllerTest {
                 "Result validates against schema",
                 JsonSchemaTest.validateJSON(result, "/gsr-ms/1.0/identify.json"));
 
-        assertEquals(2, result.getJSONArray("results").size());
+        assertEquals(1, result.getJSONArray("results").size());
         assertEquals(
                 "4326",
                 result.getJSONArray("results")
@@ -80,14 +80,14 @@ public class MapServiceControllerTest extends ControllerTest {
                 (JSONObject)
                         getAsJSON(
                                 getBaseURL()
-                                        + "/cite/MapServer/identify?f=json"
-                                        + "&geometryType=esriGeometryPoint&geometry={x: 0, y: 0}"
+                                        + "/cite/BasicPolygons/MapServer/identify?f=json"
+                                        + "&geometryType=esriGeometryPoint&geometry={x: 0, y:0}"
                                         + "&layers=all:0&imageDisplay=718,610,96&mapExtent=-126.175461,11.400420,-65.525810,"
                                         + "62.927282&tolerance=10 ");
         assertFalse(result.has("error"));
         print(result);
 
-        assertEquals(2, result.getJSONArray("results").size());
+        assertEquals(1, result.getJSONArray("results").size());
         assertEquals(
                 "4326",
                 result.getJSONArray("results")
@@ -100,8 +100,8 @@ public class MapServiceControllerTest extends ControllerTest {
                 (JSONObject)
                         getAsJSON(
                                 getBaseURL()
-                                        + "/cdf/MapServer/identify?f=json"
-                                        + "&geometryType=esriGeometryPoint&geometry={x: 500050, y: 500050}&sr=32615"
+                                        + "/cdf/Locks/MapServer/identify?f=json"
+                                        + "&geometryType=esriGeometryPoint&geometry={x:500050, y: 500050}&sr=32615"
                                         + "&layers=all:0&imageDisplay=718,610,96&mapExtent=-126.175461,11.400420,-65.525810,"
                                         + "62.927282&tolerance=10 ");
         assertFalse(result.has("error"));
@@ -111,7 +111,7 @@ public class MapServiceControllerTest extends ControllerTest {
         // respected and it was picking the bound polygon as the geom instead of the point, which is
         // null
         // (yes, weird dataset)
-        assertEquals(98, result.getJSONArray("results").size());
+        assertEquals(68, result.getJSONArray("results").size());
         assertEquals(
                 "32615",
                 result.getJSONArray("results")
@@ -127,7 +127,7 @@ public class MapServiceControllerTest extends ControllerTest {
                 (JSONObject)
                         getAsJSON(
                                 getBaseURL()
-                                        + "/cite/MapServer/find?f=json&searchText=Ash&layers=8");
+                                        + "/cite/NamedPlaces/MapServer/find?f=json&searchText=Ash&layers=0");
         System.out.println(result.toString());
         JSONArray results = (JSONArray) result.get("results");
         assertTrue("Results should have one element", results.size() == 1);

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public class QueryControllerTest extends ControllerTest {
     private String query(String service, int layerId, String params) {
-        return getBaseURL() + service + "/MapServer/" + layerId + "/query" + params;
+        return getBaseURL() + service + "/Streams/MapServer/" + layerId + "/query" + params;
     }
 
     @Test
@@ -32,7 +32,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsJSON(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90"));
         assertTrue(String.valueOf(json) + " is a JSON object", json instanceof JSONObject);
         JSONObject jsonObject = (JSONObject) json;
@@ -122,7 +122,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90"));
         assertTrue(
                 "Request with f=json returns features",
@@ -136,7 +136,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?geometryType=GeometryEnvelope&geometry=-180,-90,180,90"));
         assertTrue(
                 "Request with no format parameter return an error",
@@ -149,7 +149,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=xml&geometryType=GeometryEnvelope&geometry=-180,-90,180,90"));
         assertTrue(
                 "Request with unrecognized format returns an error",
@@ -164,7 +164,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90"));
         assertTrue(
                 "Request with short envelope; returned " + result,
@@ -179,7 +179,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryPoint&geometry=-0.0001,0.0012"));
         assertTrue(
                 "Request with short point; returned " + result,
@@ -193,7 +193,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry={xmin:-180,xmax:180,ymin:-90,ymax:90}"));
         assertTrue(
                 "Request with JSON envelope; returned " + result,
@@ -207,7 +207,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryPoint&geometry={x:-0.0001,y:0.0012}"));
         assertTrue(
                 "Request with JSON point; returned " + result,
@@ -221,7 +221,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryMultiPoint&geometry={points:[[0.0034,-0.0024],[0.0036,-0.002],[0.0031,-0.0015]]}"));
         assertTrue(
                 "Request with JSON multipoint; returned " + result,
@@ -235,7 +235,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryPolyLine&geometry={paths:[[[0.0034,-0.0024],[0.0036,-0.002],[0.0031,-0.0015]]]}"));
         assertTrue(
                 "Request with JSON polyline; returned " + result,
@@ -249,7 +249,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryPolygon&geometry={rings:[[[0.0034,-0.0024],[0.0036,-0.002],[0.0031,-0.0015],[0.0034,-0.0024]]]}"));
         assertTrue(
                 "Request with JSON polygon, returned " + result,
@@ -266,7 +266,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=NAME=\'Cam+Stream\'"));
         assertTrue(
                 "Request with valid where clause; returned " + result,
@@ -278,7 +278,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=GeometryEnvelope&geometry=-180,-90,180,90&where=invalid_filter"));
         assertTrue(
                 "Request with invalid where clause; returned " + result,
@@ -294,7 +294,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90"));
         assertTrue(
                 "Request implicitly including geometries; returned " + result,
@@ -311,7 +311,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&returnGeometry=true"));
         assertTrue(
                 "Request explicitly including geometries; returned " + result,
@@ -328,7 +328,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&returnGeometry=false"));
         assertTrue(
                 "Request excluding geometries, but don't specify fields. in this case the geometry should be returned anyway. JSON was "
@@ -347,7 +347,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&returnGeometry=false&outFields=NAME"));
         assertTrue(
                 "Request excluding geometries. JSON was " + result,
@@ -368,7 +368,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-170,-85,170,85&outSR=3857"));
         assertFalse("Response should not be empty!", result.isEmpty());
         assertTrue(
@@ -395,7 +395,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&outSR=2147483647"));
         assertTrue(
                 "Request for unknown WKID produces error; returned " + result,
@@ -409,7 +409,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-45,265,-44,264&inSR=3785"));
         assertTrue(
                 "Request explicitly including geometries; returned " + result,
@@ -426,7 +426,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=esriGeometryPolyline&geometry={paths:[[[-0.001,0],[0,0.0015]]]}"));
         System.out.println(result);
         assertTrue(
@@ -442,7 +442,7 @@ public class QueryControllerTest extends ControllerTest {
                 getAsString(
                         query(
                                 "cite",
-                                11,
+                                0,
                                 "?f=json&geometryType=GeometryPolyLine&geometry={paths:[[[-0.001,0],[0,0.0015]]]}&spatialRel=esriSpatialRelEnvelopeIntersects"));
         assertTrue(
                 "Request specifying spatialreference; returned " + result,
@@ -457,7 +457,7 @@ public class QueryControllerTest extends ControllerTest {
     @Test
     public void testReturnCountOnly() throws Exception {
         String result =
-                getAsString(query("cite", 11, "?returnCountOnly=true&f=json&returnGeometry=false"));
+                getAsString(query("cite", 0, "?returnCountOnly=true&f=json&returnGeometry=false"));
         JSONObject json = JSONObject.fromObject(result);
         int count = json.getInt("count");
 
@@ -469,8 +469,9 @@ public class QueryControllerTest extends ControllerTest {
         String query =
                 getBaseURL()
                         + "cite"
+                        + "/Streams"
                         + "/FeatureServer/"
-                        + 11
+                        + 0
                         + "/query"
                         + "?f=json&where=objectid=objectid&returnIdsOnly=true";
         JSONObject obj = (JSONObject) getAsJSON(query);

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTimeTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTimeTest.java
@@ -77,7 +77,7 @@ public class QueryControllerTimeTest extends ControllerTest {
         assertTrue(dimensionInfo.isEnabled());
         assertEquals("time", dimensionInfo.getAttribute());
         assertNotNull(getCatalog().getLayerByName(TIME_ELEVATION.getLocalPart()));
-        String rootResource = getAsString(getBaseURL() + "cite/MapServer?f=json");
+        String rootResource = getAsString(getBaseURL() + "cite/Lines/MapServer?f=json");
         assertTrue(JsonSchemaTest.validateJSON(rootResource, "gsr-ms/1.0/root.json"));
         JSONObject json = JSONObject.fromObject(rootResource);
         // TODO timeinfo is skipped for now
@@ -89,8 +89,8 @@ public class QueryControllerTimeTest extends ControllerTest {
         String query =
                 getBaseURL()
                         + "cite"
-                        + "/MapServer/"
-                        + "12"
+                        + "/TimeElevation/MapServer/"
+                        + "0"
                         + "/query"
                         + "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90";
         String result;


### PR DESCRIPTION
Sqashed commits: 5a1fb6b775e18d5c28add2ffc743cb8d0cfa855c, cb29c960a1f617f0841eee7ce14343839662c9d5, 1ac5675cce23ea51fa42628e48e585a8240ebd72

### Checklist

- [x] I've reviewed the diff myself
- [x] Note any new dependencies, link to discussion and approval status
- [x] Tests have been updated
<!-- Any other things that need to be done before merging? Add them here. -->

### Why you made these changes?
This change reshuffles the API structure such that each layer exists as a standalone folder and  has its own FeatureService or MapService.

This is to avoid issues with ArcPro attempting to enumerate all sibling layers within a particular folder/service when added to the map, and to make the API endpoints more addressable (avoid the numeric-indexing issue).

This PR also disables access to Geometry Service. 
This does geometry processing that we don't want at the moment.

### How have you solved the problem?
Shuffled the whole API endpoints to match the following scheme:

```
.../services  # will list the workspaces
.../services/example  # will list the layers in the workspace
.../services/example/layer-123/  # list the services (Feature or Map)
.../services/example/layer-123/FeatureService  # will only list the one feature layer
.../services/example/layer-123/FeatureService/0  # the only one feature layer present
.../services/example/layer-123/FeatureService/layers  # lists the one layer
```

And disabled Geometry Service

### Risks involved
There shouldn't be any.

#### Are there possible or actual performance implications for this change?
`.../services/example`: This endpoint takes a while on live as `catalog.getLayers()` seem to be a very slow call. Might need to look into optimising this further. 

### Deployment/Migration

