### PR TITLE
GSR: Enable POST to feature layer query endpoint

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -24,9 +24,9 @@ import org.opengis.feature.type.FeatureType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,7 +42,10 @@ public class QueryController extends AbstractGSRController {
         super(geoServer);
     }
 
-    @GetMapping(path = "/{layerId}/query", name = "MapServerQuery")
+    @RequestMapping(
+            path = "/{layerId}/query",
+            method = {RequestMethod.GET, RequestMethod.POST},
+            name = "MapServerQuery")
     public GSRModel query(
             @PathVariable String workspaceName,
             @PathVariable String layerName,

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -478,4 +478,12 @@ public class QueryControllerTest extends ControllerTest {
         System.out.println(obj.toString());
         assertFalse(obj.has("error"));
     }
+
+    @Test
+    public void testBasicPostQuery() throws Exception {
+        String query = getBaseURL() + "cite" + "/Streams" + "/FeatureServer/" + 0 + "/query";
+        JSONObject obj = (JSONObject) postAsJSON(query, "", "application/json");
+        System.out.println(obj.toString());
+        assertFalse(obj.has("error"));
+    }
 }


### PR DESCRIPTION


### Checklist

- [x] I've reviewed the diff myself
- [x] Note any new dependencies, link to discussion and approval status
- [x] Tests have been updated
<!-- Any other things that need to be done before merging? Add them here. -->

### Why you made these changes?
Big layers with LOTs of feature objects like layer-7251 and layer-7252 (linz.staging.kx.gd) fails to load its features on ArcPRO, as it tries to POST to the `/query` endpoint in hopes to fetch the geometries. 

It seems like ArcPRO does a `POST` query instead of a `GET` when there are lots of feature objects. It's basically trying to do the same as a GET query to get the geometries, so enable POST to return the same response.

### How have you solved the problem?
Added a `POSTMapServerQuery` endpoint to function exactly like how it would do with `GET`

### Risks involved
There shouldn't be any.

#### Are there possible or actual performance implications for this change?
It's certainly not a snappy performance since there are lots of features (500000+) when this request is called.

### Deployment/Migration

