### PR TITLE
GSR: Disable access to demo data and editing

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/GSRRestConfig.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/GSRRestConfig.java
@@ -23,6 +23,7 @@ public class GSRRestConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/gsr-demos/**").addResourceLocations("/demos/");
+        // Disable GSR demos by default
+        // registry.addResourceHandler("/gsr-demos/**").addResourceLocations("/demos/");
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -33,8 +33,10 @@ import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geotools.feature.FeatureCollection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
 
 /** Controller for the Feature Service layer endpoint */
 @RestController
@@ -157,6 +159,11 @@ public class FeatureLayerController extends AbstractGSRController {
                     boolean returnEditMoment)
             throws IOException, ServiceException {
 
+        if (FeatureLayer.isEditDisabled()) {
+            throw new HttpClientErrorException(
+                    HttpStatus.METHOD_NOT_ALLOWED, "Editing is disabled");
+        }
+
         return deleteFeatures(
                 workspaceName,
                 layerName,
@@ -277,6 +284,12 @@ public class FeatureLayerController extends AbstractGSRController {
             @RequestParam(name = "returnEditMoment", required = false, defaultValue = "false")
                     boolean returnEditMoment)
             throws IOException, ServiceException {
+
+        if (FeatureLayer.isEditDisabled()) {
+            throw new HttpClientErrorException(
+                    HttpStatus.METHOD_NOT_ALLOWED, "Editing is disabled");
+        }
+
         FeatureArray featureArray = jsonStringToFeatureArray(features);
         return updateFeatures(
                 featureArray,
@@ -340,6 +353,12 @@ public class FeatureLayerController extends AbstractGSRController {
             @RequestParam(name = "returnEditMoment", required = false, defaultValue = "false")
                     boolean returnEditMoment)
             throws IOException, ServiceException {
+
+        if (FeatureLayer.isEditDisabled()) {
+            throw new HttpClientErrorException(
+                    HttpStatus.METHOD_NOT_ALLOWED, "Editing is disabled");
+        }
+
         FeatureArray featureArray = jsonStringToFeatureArray(features);
         return addFeatures(
                 featureArray,
@@ -413,6 +432,11 @@ public class FeatureLayerController extends AbstractGSRController {
             @RequestParam(name = "returnEditMoment", required = false, defaultValue = "false")
                     boolean returnEditMoment)
             throws IOException, ServiceException {
+
+        if (FeatureLayer.isEditDisabled()) {
+            throw new HttpClientErrorException(
+                    HttpStatus.METHOD_NOT_ALLOWED, "Editing is disabled");
+        }
 
         EditResults addEditResults = null;
         EditResults updateEditResults = null;
@@ -540,6 +564,11 @@ public class FeatureLayerController extends AbstractGSRController {
             @RequestParam(name = "honorSequenceOfEdits", required = false, defaultValue = "false")
                     boolean honorSequenceOfEdits)
             throws IOException, ServiceException {
+
+        if (FeatureLayer.isEditDisabled()) {
+            throw new HttpClientErrorException(
+                    HttpStatus.METHOD_NOT_ALLOWED, "Editing is disabled");
+        }
 
         List<EditResults> editResults = new ArrayList<>();
 

--- a/src/community/gsr/src/main/resources/applicationContext.xml
+++ b/src/community/gsr/src/main/resources/applicationContext.xml
@@ -23,7 +23,7 @@
         <constructor-arg ref="geoServer" />
     </bean>
 
-    <mvc:resources mapping="/gsr-demos/**" location="classpath:/demos/"/>
+    <!-- <mvc:resources mapping="/gsr-demos/**" location="classpath:/demos/"/> -->
 
     <!-- <mvc:annotation-driven/> -->
     <context:component-scan base-package="org.geoserver.gsr.api" />


### PR DESCRIPTION

### Why you made these changes?
We don't want testers to be able to access the demo data in GSR. 

The GSR plugin also supports data editing.

Although KX authentication layer should block this (we never propagate editing permissions to GS), safe to disable this feature in general. 

### How have you solved the problem?
Commented the mapping to the demo resource, and the handler.

Let editing be conditional on a property key `DISABLE_GSR_EDIT_KEY`
