### PR TITLE
GSR: Return 404 for invalid/non-existent endpoints

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureController.java
@@ -22,6 +22,7 @@ import org.geoserver.gsr.model.map.LayerOrTable;
 import org.geoserver.gsr.translate.feature.FeatureEncoder;
 import org.geoserver.gsr.translate.geometry.SpatialReferences;
 import org.geoserver.gsr.translate.map.LayerDAO;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.wfs.json.JSONType;
 import org.geotools.data.FeatureSource;
@@ -30,6 +31,7 @@ import org.opengis.filter.Filter;
 import org.opengis.referencing.FactoryException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -59,11 +61,15 @@ public class FeatureController extends AbstractGSRController {
         LayerOrTable l = LayerDAO.find(catalog, workspaceName, layerName, layerId);
 
         if (null == l) {
-            throw new NoSuchElementException(
+            throw new APIException(
+                    "InvalidTableOrLayer",
                     "No table or layer in workspace \""
                             + workspaceName
                             + "\" for name "
-                            + layerName);
+                            + layerName
+                            + "with the id "
+                            + layerId,
+                    HttpStatus.NOT_FOUND);
         }
 
         FeatureTypeInfo featureType = (FeatureTypeInfo) l.layer.getResource();
@@ -84,8 +90,10 @@ public class FeatureController extends AbstractGSRController {
         org.opengis.feature.Feature[] featureArr =
                 featureColl.toArray(new org.opengis.feature.Feature[0]);
         if (featureArr.length == 0) {
-            throw new NoSuchElementException(
-                    "No feature in layer or table " + layerId + " with id " + featureId);
+            throw new APIException(
+                    "InvalidFeature",
+                    "No feature in layer or table " + layerId + " with id " + featureId,
+                    HttpStatus.NOT_FOUND);
         }
         SpatialReference spatialReference =
                 SpatialReferences.fromCRS(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -29,6 +29,7 @@ import org.geoserver.gsr.translate.feature.FeatureDAO;
 import org.geoserver.gsr.translate.feature.FeatureEncoder;
 import org.geoserver.gsr.translate.feature.LayerEditsEncoder;
 import org.geoserver.gsr.translate.map.LayerDAO;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.wfs.json.JSONType;
 import org.geotools.feature.FeatureCollection;
@@ -74,11 +75,15 @@ public class FeatureLayerController extends AbstractGSRController {
                             + e);
         }
         if (entry == null) {
-            throw new NoSuchElementException(
+            throw new APIException(
+                    "InvalidTableOrLayer",
                     "No table or layer in workspace \""
                             + workspaceName
                             + "\" for name "
-                            + layerName);
+                            + layerName
+                            + " with the id "
+                            + layerId,
+                    HttpStatus.NOT_FOUND);
         }
         FeatureLayer layer = new FeatureLayer(entry);
         layer.getPath()

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerListController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerListController.java
@@ -11,10 +11,12 @@ import org.geoserver.gsr.api.AbstractGSRController;
 import org.geoserver.gsr.model.AbstractGSRModel.Link;
 import org.geoserver.gsr.model.map.LayersAndTables;
 import org.geoserver.gsr.translate.map.LayerDAO;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.wfs.json.JSONType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,6 +40,12 @@ public class FeatureLayerListController extends AbstractGSRController {
     public LayersAndTables getLayers(
             @PathVariable String workspaceName, @PathVariable String layerName) throws IOException {
         LayersAndTables layers = LayerDAO.find(catalog, workspaceName, layerName);
+        if (layers.layers.size() == 0 & layers.tables.size() == 0) {
+            throw new APIException(
+                    "InvalidLayerName",
+                    layerName + " does not correspond to a layer in the workspace.",
+                    HttpStatus.NOT_FOUND);
+        }
         layers.getPath()
                 .addAll(
                         Arrays.asList(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/LayerListController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/LayerListController.java
@@ -15,10 +15,12 @@ import org.geoserver.gsr.api.AbstractGSRController;
 import org.geoserver.gsr.model.AbstractGSRModel.Link;
 import org.geoserver.gsr.model.map.LayersAndTables;
 import org.geoserver.gsr.translate.map.LayerDAO;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.wfs.json.JSONType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,6 +44,12 @@ public class LayerListController extends AbstractGSRController {
     public LayersAndTables getLayers(
             @PathVariable String workspaceName, @PathVariable String layerName) {
         LayersAndTables layers = LayerDAO.find(catalog, workspaceName, layerName);
+        if (layers.layers.size() == 0 & layers.tables.size() == 0) {
+            throw new APIException(
+                    "InvalidLayerName",
+                    layerName + " does not correspond to a layer in the workspace.",
+                    HttpStatus.NOT_FOUND);
+        }
         layers.getPath()
                 .addAll(
                         Arrays.asList(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,6 +32,7 @@ import org.geoserver.gsr.model.map.LayerOrTable;
 import org.geoserver.gsr.model.map.MapServiceRoot;
 import org.geoserver.gsr.translate.feature.FeatureDAO;
 import org.geoserver.gsr.translate.map.LayerDAO;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.WMSInfo;
@@ -44,6 +44,7 @@ import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.Filter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -72,8 +73,10 @@ public class MapServiceController extends AbstractGSRController {
             @PathVariable String workspaceName, @PathVariable String layerName) throws IOException {
         WorkspaceInfo workspace = geoServer.getCatalog().getWorkspaceByName(workspaceName);
         if (workspace == null) {
-            throw new NoSuchElementException(
-                    "Workspace name " + workspaceName + " does not correspond to any workspace.");
+            throw new APIException(
+                    "InvalidWorkspaceName",
+                    workspaceName + " does not correspond to any workspaces.",
+                    HttpStatus.NOT_FOUND);
         }
         WMSInfo service = geoServer.getService(workspace, WMSInfo.class);
         if (service == null) {
@@ -81,9 +84,15 @@ public class MapServiceController extends AbstractGSRController {
         }
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
         LayerInfo l = geoServer.getCatalog().getLayerByName(layerName);
-        if (l.getType() == PublishedType.VECTOR
+        if (l != null
+                && l.getType() == PublishedType.VECTOR
                 && l.getResource().getStore().getWorkspace().equals(workspace)) {
             layersInWorkspace.add(l);
+        } else {
+            throw new APIException(
+                    "InvalidLayerName",
+                    layerName + " does not correspond to a layer in the workspace.",
+                    HttpStatus.NOT_FOUND);
         }
         layersInWorkspace.sort(LayerNameComparator.INSTANCE);
         MapServiceRoot root =
@@ -121,6 +130,17 @@ public class MapServiceController extends AbstractGSRController {
             @PathVariable Integer layerId)
             throws IOException {
         LayerOrTable layer = LayerDAO.find(catalog, workspaceName, layerName, layerId);
+        if (layer == null) {
+            throw new APIException(
+                    "InvalidTableOrLayer",
+                    "No table or layer in workspace \""
+                            + workspaceName
+                            + "\" for name "
+                            + layerName
+                            + " with the id "
+                            + layerId,
+                    HttpStatus.NOT_FOUND);
+        }
         layer.getPath()
                 .addAll(
                         Arrays.asList(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -18,12 +18,14 @@ import org.geoserver.gsr.model.map.LayersAndTables;
 import org.geoserver.gsr.translate.feature.FeatureDAO;
 import org.geoserver.gsr.translate.feature.FeatureEncoder;
 import org.geoserver.gsr.translate.map.LayerDAO;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.wfs.json.JSONType;
 import org.geotools.feature.FeatureCollection;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,7 +86,12 @@ public class QueryController extends AbstractGSRController {
             throws IOException {
 
         LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName, layerName);
-
+        if (layersAndTables.layers.size() == 0 & layersAndTables.tables.size() == 0) {
+            throw new APIException(
+                    "InvalidLayerName",
+                    layerName + " does not correspond to a layer in the workspace.",
+                    HttpStatus.NOT_FOUND);
+        }
         FeatureCollection<? extends FeatureType, ? extends Feature> features =
                 FeatureDAO.getFeatureCollectionForLayerWithId(
                         workspaceName,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/map/LayerDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/map/LayerDAO.java
@@ -39,7 +39,8 @@ public class LayerDAO {
         // short list all layers
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
         LayerInfo l = catalog.getLayerByName(layerName);
-        if (l.enabled()
+        if (l != null
+                && l.enabled()
                 && l.getType() == PublishedType.VECTOR
                 && l.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
             layersInWorkspace.add(l);
@@ -87,7 +88,8 @@ public class LayerDAO {
         int idCounter = 0;
         List<LayerInfo> layersInWorkspace = new ArrayList<>();
         LayerInfo li = catalog.getLayerByName(layerName);
-        if (li.enabled()
+        if (li != null
+                && li.enabled()
                 && li.getType() == PublishedType.VECTOR
                 && li.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
             layersInWorkspace.add(li);

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureLayerListControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureLayerListControllerTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 public class FeatureLayerListControllerTest extends ControllerTest {
     private String query(String service, String params) {
-        return getBaseURL() + service + "/Lines/FeatureServer/layers";
+        return getBaseURL() + service + "/BasicPolygons/FeatureServer/layers";
     }
 
     @Test

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTimeTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTimeTest.java
@@ -77,7 +77,7 @@ public class QueryControllerTimeTest extends ControllerTest {
         assertTrue(dimensionInfo.isEnabled());
         assertEquals("time", dimensionInfo.getAttribute());
         assertNotNull(getCatalog().getLayerByName(TIME_ELEVATION.getLocalPart()));
-        String rootResource = getAsString(getBaseURL() + "cite/Lines/MapServer?f=json");
+        String rootResource = getAsString(getBaseURL() + "cite/TimeElevation/MapServer?f=json");
         assertTrue(JsonSchemaTest.validateJSON(rootResource, "gsr-ms/1.0/root.json"));
         JSONObject json = JSONObject.fromObject(rootResource);
         // TODO timeinfo is skipped for now


### PR DESCRIPTION
## Return 404 for invalid/non-existent endpoints
Currently, if you hit a endpoint with:
- an invalid layer/workspace name: `rest/services/weirdname/layer-unknown/`
- or an endpoint that doesn't exist: `rest/services/example.com/layer-123/UnknownServer/` 

It will return a 500 response. Either because it was throwing a `NoSuchElementException` (intentional) or a `NullPointerException` (when a layer could not be found' not handled).

We want to change it to a 404 response with a meaningful error message. 

These changes will handle exceptions thrown in GSR more gracefully. There were lots of areas that could throw a `NullPointerException`, especially if an invalid layer was trying to be retrieved. 
