### PR TITLE
GSR: Add monitoring support

### DIFF
--- a/src/community/gsr/pom.xml
+++ b/src/community/gsr/pom.xml
@@ -37,6 +37,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-monitor-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/GSRMonitorCallback.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/GSRMonitorCallback.java
@@ -1,17 +1,12 @@
-/**
- * 
- */
+/** */
 package org.geoserver.gsr;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-
 import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.monitor.Monitor;
 import org.geoserver.monitor.MonitorConfig;
 import org.geoserver.monitor.RequestData;
@@ -24,16 +19,14 @@ import org.geoserver.platform.Service;
 import org.geoserver.platform.ServiceException;
 import org.geotools.util.logging.Logging;
 
-/**
- * 
- */
+/** */
 public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority {
 
     static final Logger LOGGER = Logging.getLogger(GSRMonitorCallback.class);
 
     Monitor monitor;
     Catalog catalog;
-    
+
     public GSRMonitorCallback(Monitor monitor, Catalog catalog) {
         this.monitor = monitor;
         this.catalog = catalog;
@@ -46,7 +39,7 @@ public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority
     }
 
     @Override
-    public Operation operationDispatched(Request request, Operation operation) {                
+    public Operation operationDispatched(Request request, Operation operation) {
         RequestData data = monitor.current();
         if (data == null) {
             // will happen in cases where the filter is not active
@@ -56,34 +49,35 @@ public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority
         if (service != null && service.getId().equals("GSR")) {
             // tweak some GSR-specific things
             data.setOwsVersion(Double.toString(GSRConfig.CURRENT_VERSION));
-            
-            List<String> params = Arrays.stream(operation.getParameters())
-                    .map(o -> o != null ? o.toString() : null)
-                    .collect(Collectors.toList());
+
+            List<String> params =
+                    Arrays.stream(operation.getParameters())
+                            .map(o -> o != null ? o.toString() : null)
+                            .collect(Collectors.toList());
 
             // TODO: implement different logic based on the operation
-//            switch(operation.getId()) {
-//            case "GetServices":
-//            case "FeatureServerGetService":
-//            case "FeatureServerGetFeature":
-//            case "FeatureServerGetLayers":
-//            case "FeatureServerGetLegend":
-//            case "FeatureServerQuery":
-//            case "FeatureServerAddFeatures":
-//            case "FeatureServerApplyEdits":
-//            case "FeatureServerDeleteFeatures":
-//            case "FeatureServerUpdateFeatures":
-//            case "MapServerGetService":
-//            case "MapServerGetLayers":
-//            case "MapServerGetLayer":
-//            case "MapServerExportLayerMap":
-//            case "MapServerExportMap":
-//            case "MapServerExportMapImage":
-//            case "MapServerFind":
-//            case "MapServerGetLegend":
-//            case "MapServerIdentify":
-//            case "MapServerQuery":
-//            }            
+            //            switch(operation.getId()) {
+            //            case "GetServices":
+            //            case "FeatureServerGetService":
+            //            case "FeatureServerGetFeature":
+            //            case "FeatureServerGetLayers":
+            //            case "FeatureServerGetLegend":
+            //            case "FeatureServerQuery":
+            //            case "FeatureServerAddFeatures":
+            //            case "FeatureServerApplyEdits":
+            //            case "FeatureServerDeleteFeatures":
+            //            case "FeatureServerUpdateFeatures":
+            //            case "MapServerGetService":
+            //            case "MapServerGetLayers":
+            //            case "MapServerGetLayer":
+            //            case "MapServerExportLayerMap":
+            //            case "MapServerExportMap":
+            //            case "MapServerExportMapImage":
+            //            case "MapServerFind":
+            //            case "MapServerGetLegend":
+            //            case "MapServerIdentify":
+            //            case "MapServerQuery":
+            //            }
             try {
                 // TODO: WFS/etc does this pre-query like we do here, couldn't we do it during
                 // the query when we figure out what's actually being asked for?
@@ -92,16 +86,16 @@ public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority
             } catch (Exception e) {
                 LOGGER.warning("Error getting resources for auditlog from GSR request");
             }
-            
+
             if (monitor.getConfig().getBboxMode() == MonitorConfig.BboxMode.FULL) {
                 // TODO: which operations take a bounding box or spatial filter?
             }
-            
+
             monitor.update();
         }
         return operation;
-    }    
-    
+    }
+
     @Override
     public Request init(Request request) {
         // TODO Auto-generated method stub
@@ -115,7 +109,8 @@ public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority
     }
 
     @Override
-    public Response responseDispatched(Request request, Operation operation, Object result, Response response) {
+    public Response responseDispatched(
+            Request request, Operation operation, Object result, Response response) {
         // TODO Auto-generated method stub
         return null;
     }
@@ -123,7 +118,7 @@ public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority
     @Override
     public void finished(Request request) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/GSRMonitorCallback.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/GSRMonitorCallback.java
@@ -1,0 +1,133 @@
+/**
+ * 
+ */
+package org.geoserver.gsr;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.monitor.Monitor;
+import org.geoserver.monitor.MonitorConfig;
+import org.geoserver.monitor.RequestData;
+import org.geoserver.ows.DispatcherCallback;
+import org.geoserver.ows.Request;
+import org.geoserver.ows.Response;
+import org.geoserver.platform.ExtensionPriority;
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.Service;
+import org.geoserver.platform.ServiceException;
+import org.geotools.util.logging.Logging;
+
+/**
+ * 
+ */
+public class GSRMonitorCallback implements DispatcherCallback, ExtensionPriority {
+
+    static final Logger LOGGER = Logging.getLogger(GSRMonitorCallback.class);
+
+    Monitor monitor;
+    Catalog catalog;
+    
+    public GSRMonitorCallback(Monitor monitor, Catalog catalog) {
+        this.monitor = monitor;
+        this.catalog = catalog;
+    }
+
+    @Override
+    public Service serviceDispatched(Request request, Service service) throws ServiceException {
+        // TODO Auto-generated method stub
+        return service;
+    }
+
+    @Override
+    public Operation operationDispatched(Request request, Operation operation) {                
+        RequestData data = monitor.current();
+        if (data == null) {
+            // will happen in cases where the filter is not active
+            return operation;
+        }
+        Service service = operation.getService();
+        if (service != null && service.getId().equals("GSR")) {
+            // tweak some GSR-specific things
+            data.setOwsVersion(Double.toString(GSRConfig.CURRENT_VERSION));
+            
+            List<String> params = Arrays.stream(operation.getParameters())
+                    .map(o -> o != null ? o.toString() : null)
+                    .collect(Collectors.toList());
+
+            // TODO: implement different logic based on the operation
+//            switch(operation.getId()) {
+//            case "GetServices":
+//            case "FeatureServerGetService":
+//            case "FeatureServerGetFeature":
+//            case "FeatureServerGetLayers":
+//            case "FeatureServerGetLegend":
+//            case "FeatureServerQuery":
+//            case "FeatureServerAddFeatures":
+//            case "FeatureServerApplyEdits":
+//            case "FeatureServerDeleteFeatures":
+//            case "FeatureServerUpdateFeatures":
+//            case "MapServerGetService":
+//            case "MapServerGetLayers":
+//            case "MapServerGetLayer":
+//            case "MapServerExportLayerMap":
+//            case "MapServerExportMap":
+//            case "MapServerExportMapImage":
+//            case "MapServerFind":
+//            case "MapServerGetLegend":
+//            case "MapServerIdentify":
+//            case "MapServerQuery":
+//            }            
+            try {
+                // TODO: WFS/etc does this pre-query like we do here, couldn't we do it during
+                // the query when we figure out what's actually being asked for?
+                // big assumption we can resolve /{index}/ later...
+                data.setResources(Collections.singletonList(String.join(":", params)));
+            } catch (Exception e) {
+                LOGGER.warning("Error getting resources for auditlog from GSR request");
+            }
+            
+            if (monitor.getConfig().getBboxMode() == MonitorConfig.BboxMode.FULL) {
+                // TODO: which operations take a bounding box or spatial filter?
+            }
+            
+            monitor.update();
+        }
+        return operation;
+    }    
+    
+    @Override
+    public Request init(Request request) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Object operationExecuted(Request request, Operation operation, Object result) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Response responseDispatched(Request request, Operation operation, Object result, Response response) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void finished(Request request) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public int getPriority() {
+        return LOWEST;
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -108,7 +108,7 @@ public class FeatureServiceController extends QueryController {
         return root;
     }
 
-    @GetMapping(path = "/query", name="FeatureServerQuery")
+    @GetMapping(path = "/query", name = "FeatureServerQuery")
     public FeatureServiceQueryResult query(
             @PathVariable String workspaceName,
             @PathVariable String layerName,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -39,7 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>Also includes all endpoints from {@link QueryController}
  */
 @APIService(
-        service = "Feature",
+        service = "GSR",
         version = "1.0",
         landingPage = "gsr/rest/services",
         serviceClass = WFSInfo.class)
@@ -54,7 +54,7 @@ public class FeatureServiceController extends QueryController {
         super(geoServer);
     }
 
-    @GetMapping
+    @GetMapping(name = "FeatureServerGetService")
     @HTMLResponseBody(templateName = "feature.ftl", fileName = "feature.html")
     public FeatureServiceRoot featureServiceGet(
             @PathVariable String workspaceName, @PathVariable String layerName) {
@@ -108,7 +108,7 @@ public class FeatureServiceController extends QueryController {
         return root;
     }
 
-    @GetMapping(path = "/query")
+    @GetMapping(path = "/query", name="FeatureServerQuery")
     public FeatureServiceQueryResult query(
             @PathVariable String workspaceName,
             @PathVariable String layerName,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/GenerateKMLController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/GenerateKMLController.java
@@ -37,7 +37,7 @@ public class GenerateKMLController {
 
     @Autowired private Dispatcher dispatcher;
 
-    @GetMapping(name="MapServerGenerateKML")
+    @GetMapping(name = "MapServerGenerateKML")
     public void generateKml(
             @RequestParam(name = "layers") String layers,
             @PathVariable(name = "workspaceName") String workspaceName,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/GenerateKMLController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/GenerateKMLController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Simple Generate KML end point. Just redirect to GS KML service */
 @APIService(
-        service = "MapServer",
+        service = "GSR",
         version = "1.0",
         landingPage = "/gsr/rest/services",
         serviceClass = WMSInfo.class)
@@ -37,7 +37,7 @@ public class GenerateKMLController {
 
     @Autowired private Dispatcher dispatcher;
 
-    @GetMapping
+    @GetMapping(name="MapServerGenerateKML")
     public void generateKml(
             @RequestParam(name = "layers") String layers,
             @PathVariable(name = "workspaceName") String workspaceName,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/relationship/RelationshipController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/relationship/RelationshipController.java
@@ -25,12 +25,13 @@ import org.springframework.web.bind.annotation.*;
 
 /** Controller for the Relationship Service */
 @APIService(
-        service = "Relationships",
+        service = "GSR",
         version = "1.0",
         landingPage = "/gsr/rest/services",
         serviceClass = WFSInfo.class)
 @RestController
 @RequestMapping(
+        name = "Relationships",
         path = "/gsr/relationships/{workspaceName}",
         produces = {MediaType.APPLICATION_JSON_VALUE, JSONType.jsonp})
 public class RelationshipController {

--- a/src/community/gsr/src/main/resources/applicationContext.xml
+++ b/src/community/gsr/src/main/resources/applicationContext.xml
@@ -33,6 +33,11 @@
     <bean id="gsrDispatcher" class="org.geoserver.gsr.GSRDispatcher"/>
     <bean id="gsrExceptionHandler" class="org.geoserver.gsr.GSRExceptionHandler"/>
 
+    <bean id="gsrMonitorCallback" class="org.geoserver.gsr.GSRMonitorCallback">
+      <constructor-arg ref="monitor"/>
+      <constructor-arg ref="catalog"/>
+    </bean>
+
     <bean id="gsrServiceFactory" class="org.geoserver.ogcapi.APIServiceFactoryBean">
         <constructor-arg index="0" value="GSR"/>
         <constructor-arg index="1" value="10.51"/>

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/MonitorCallback.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/MonitorCallback.java
@@ -26,12 +26,13 @@ import org.geoserver.monitor.ows.wms.GetMapHandler;
 import org.geoserver.ows.DispatcherCallback;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.Response;
+import org.geoserver.platform.ExtensionPriority;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
 import org.geoserver.platform.ServiceException;
 
-public class MonitorCallback implements DispatcherCallback {
+public class MonitorCallback implements DispatcherCallback, ExtensionPriority {
 
     List<RequestObjectHandler> handlers = new ArrayList<>();
 
@@ -150,5 +151,10 @@ public class MonitorCallback implements DispatcherCallback {
         }
 
         return op.getId();
+    }
+
+    @Override
+    public int getPriority() {
+        return HIGHEST / 2;
     }
 }

--- a/src/extension/monitor/core/src/main/resources/org/geoserver/monitor/filter.properties
+++ b/src/extension/monitor/core/src/main/resources/org/geoserver/monitor/filter.properties
@@ -13,3 +13,4 @@
 /web
 /web/**
 /pdf/**
+/apicss/**


### PR DESCRIPTION
WIP — needs more work on:

* dealing with endpoints like `/query` that take querystring parameters: right now these get merged with the URL path variables into resources.
* more work on service/operation/suboperation naming: there's some unnamed endpoints
* for FeatureServer/MapServer, it'd be more use to return the actual layer qnames from the catalog rather than the server name & layer index. For `/myworkspace/rest/services/myworkspace/mylayer/FeatureServer/0` it's nbd since it's always `0` but that won't always be the case.

Right now it populates the service as "GSR" consistently; populates Operation; adds the path + view query parameters to resources. And does it without breaking either Monitor or GSR.