### PR TITLE
GSR: Block layer changesets views

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/catalog/CatalogServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/catalog/CatalogServiceController.java
@@ -99,6 +99,7 @@ public class CatalogServiceController extends AbstractGSRController {
                                                         .getStore()
                                                         .getWorkspace()
                                                         .getName()))
+                        .filter(l -> !l.getName().contains("changeset"))
                         .map(l -> workspaceName + "/" + l.getName())
                         .collect(Collectors.toList());
 
@@ -130,7 +131,7 @@ public class CatalogServiceController extends AbstractGSRController {
                     HttpStatus.NOT_FOUND);
         }
         LayerInfo li = catalog.getLayerByName(layerName);
-        if (li != null && li.getResource().getStore().getWorkspace().equals(ws)) {
+        if (li != null && li.getResource().getStore().getWorkspace().equals(ws) && !li.getName().contains("changeset")) {
             fillServices(services, li, workspaceName);
         } else {
             throw new APIException(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -74,7 +74,8 @@ public class FeatureServiceController extends QueryController {
         LayerInfo l = geoServer.getCatalog().getLayerByName(layerName);
         if (l != null
                 && l.getType() == PublishedType.VECTOR
-                && l.getResource().getStore().getWorkspace().equals(workspace)) {
+                && l.getResource().getStore().getWorkspace().equals(workspace)
+                && !l.getName().contains("changeset")) {
             layersInWorkspace.add(l);
         } else {
             throw new APIException(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -86,7 +86,8 @@ public class MapServiceController extends AbstractGSRController {
         LayerInfo l = geoServer.getCatalog().getLayerByName(layerName);
         if (l != null
                 && l.getType() == PublishedType.VECTOR
-                && l.getResource().getStore().getWorkspace().equals(workspace)) {
+                && l.getResource().getStore().getWorkspace().equals(workspace)
+                && !l.getName().contains("changeset")) {
             layersInWorkspace.add(l);
         } else {
             throw new APIException(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/map/LayerDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/map/LayerDAO.java
@@ -42,7 +42,8 @@ public class LayerDAO {
         if (l != null
                 && l.enabled()
                 && l.getType() == PublishedType.VECTOR
-                && l.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
+                && l.getResource().getStore().getWorkspace().getName().equals(workspaceName)
+                && !l.getName().contains("changeset")) {
             layersInWorkspace.add(l);
         }
         // sort for "consistent" order
@@ -91,7 +92,8 @@ public class LayerDAO {
         if (li != null
                 && li.enabled()
                 && li.getType() == PublishedType.VECTOR
-                && li.getResource().getStore().getWorkspace().getName().equals(workspaceName)) {
+                && li.getResource().getStore().getWorkspace().getName().equals(workspaceName)
+                && !li.getName().contains("changeset")) {
             layersInWorkspace.add(li);
         }
         layersInWorkspace.sort(LayerNameComparator.INSTANCE);


### PR DESCRIPTION
When filtering the endpoints via layer name, apply an additional check that there is no `changeset` included in the name. 
Changesets in GSR is not supported out of the box, as there is no way to pass the time parameters through to the view. 