### PR TITLE
GSR: Enable POST to feature server endpoint

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -30,6 +30,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,6 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(
         path = "/gsr/rest/services/{workspaceName}/{layerName}/FeatureServer",
+        method = {RequestMethod.GET, RequestMethod.POST},
         produces = {MediaType.APPLICATION_JSON_VALUE, JSONType.jsonp})
 public class FeatureServiceController extends QueryController {
 

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureServiceControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/feature/FeatureServiceControllerTest.java
@@ -41,6 +41,14 @@ public class FeatureServiceControllerTest extends ControllerTest {
     }
 
     @Test
+    public void testBasicPostQuery() throws Exception {
+        String query = query("cite", "BasicPolygons", "?f=json");
+        JSONObject obj = (JSONObject) postAsJSON(query, "", "application/json");
+        System.out.println("POST: " + obj.toString());
+        assertFalse(obj.has("error"));
+    }
+
+    @Test
     public void testQuery() throws Exception {
         JSON result = getAsJSON(queryServiceUrl());
         System.out.println(result.toString());


### PR DESCRIPTION
### Checklist

- [x] I've reviewed the diff myself
- [x] Note any new dependencies, link to discussion and approval status
- [x] Tests have been updated
- [x] Tested locally
<!-- Any other things that need to be done before merging? Add them here. -->

### Why you made these changes?
In AGOL experience builder, tables don't seem to want to load our attribute data. This might be related to POST to `/FeatureServer/` throwing 500 errors. It looks like Esri expects a POST to this API to return the same content as a GET

Add support for POST requests to this endpoint, returning the same content as a GET request.

### How have you solved the problem?
Added `RequestMethod.POST` to the available methods in the endpoint mappings.