### PR TITLE
GSR: Give `returnCountOnly` precedence in query request

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -110,10 +110,13 @@ public class QueryController extends AbstractGSRController {
                         returnGeometry,
                         outFieldsText,
                         layersAndTables);
-        if (returnIdsOnly) {
-            return FeatureEncoder.objectIds(features);
-        } else if (returnCountOnly) {
+        // returnCountOnly should take precedence over returnIdsOnly.
+        // Sometimes both count and Ids are requested, but the count is expected in
+        // some ArcGIS softwares (e.g. AGOL) to be returned when loading attribute tables.
+        if (returnCountOnly) {
             return FeatureEncoder.count(features);
+        } else if (returnIdsOnly) {
+            return FeatureEncoder.objectIds(features);
         } else {
             FeatureList featureList =
                     new FeatureList(features, returnGeometry, outSRText, quantizationParameters);

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -465,6 +465,22 @@ public class QueryControllerTest extends ControllerTest {
     }
 
     @Test
+    public void testReturnCountAndIdsOnly() throws Exception {
+        // When both returnCountOnly and returnIdsOnly is given, returnCountOnly should take
+        // precedence
+        String result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?returnIdsOnly=true&returnCountOnly=true&f=json&returnGeometry=false"));
+        JSONObject json = JSONObject.fromObject(result);
+        int count = json.getInt("count");
+
+        assertTrue("FeatureCount result was: " + result, count == 2);
+    }
+
+    @Test
     public void testBasicQuery() throws Exception {
         String query =
                 getBaseURL()


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
If you include `returnIdsOnly=true` _and_ `returnCountOnly=true` then AGOL expects the `count: ...` only, whereas we return the ids only.

E.g. the output of a request to

```.../FeatureServer/0/query?f=json&returnIdsOnly=true&returnCountOnly=true&returnGeometry=false&spatialRel=esriSpatialRelIntersects&where=1%3D1```

should match the output of a request to

```
.../FeatureServer/0/query?f=json&returnCountOnly=true&returnGeometry=false&spatialRel=esriSpatialRelIntersects&where=1%3D1
```

e.g. 

```{"count":123123}```

- [x] Tested locally, and a test has been added