### PR TITLE
GSR: `GSRFunctionFactory` to register SQL functions to their equivalent ECQL functions

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRFunctionFactory.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRFunctionFactory.java
@@ -1,0 +1,172 @@
+/*
+ * (c) 2024 Koordinates Limited
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gsr.function;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.NameImpl;
+import org.geotools.filter.FunctionFactory;
+import org.geotools.util.logging.Logging;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
+import org.opengis.filter.expression.Literal;
+
+/** */
+public class GSRFunctionFactory implements FunctionFactory {
+    // https://doc.arcgis.com/en/arcgis-online/reference/sql-agol.htm
+    // String Functions
+    static final Name STRING_LOWER = new NameImpl("LOWER");
+
+    static final Name STRING_UPPER = new NameImpl("UPPER");
+
+    static final Name STRING_CHARLENGTH = new NameImpl("CHAR_LENGTH");
+
+    static final Name STRING_CONCAT = new NameImpl("CONCAT");
+
+    static final Name STRING_POSITION = new NameImpl("POSITION");
+
+    static final Name STRING_SUBSTIRNG = new NameImpl("SUBSTRING");
+
+    // Date Functions
+    static final Name DATE_CURRENT_TIME = new NameImpl("CURRENT_TIME");
+
+    // Numeric Functions
+    static final Name NUMERIC_ABS = new NameImpl("ABS");
+
+    static final Name NUMERIC_CEILING = new NameImpl("CEILING");
+
+    static final Name NUMERIC_COS = new NameImpl("COS");
+
+    static final Name NUMERIC_CAST = new NameImpl("CAST");
+
+    static final Name NUMERIC_FLOOR = new NameImpl("FLOOR");
+
+    static final Name NUMERIC_LOG = new NameImpl("LOG");
+
+    static final Name NUMERIC_LOG10 = new NameImpl("LOG10");
+
+    static final Name NUMERIC_MOD = new NameImpl("MOD");
+
+    static final Name NUMERIC_POWER = new NameImpl("POWER");
+
+    static final Name NUMERIC_ROUND = new NameImpl("ROUND");
+
+    static final Name NUMERIC_SIN = new NameImpl("SIN");
+
+    static final Name NUMERIC_TAN = new NameImpl("TAN");
+
+    FilterFactory ff;
+
+    static final Logger LOGGER = Logging.getLogger(GSRFunctionFactory.class);
+
+    List<FunctionName> functionNames;
+
+    public GSRFunctionFactory() {
+        ff = CommonFactoryFinder.getFilterFactory(null);
+        List<FunctionName> names = new ArrayList<>();
+
+        // register string functions
+        names.add(ff.functionName(STRING_LOWER, 1));
+        names.add(ff.functionName(STRING_UPPER, 1));
+        names.add(ff.functionName(STRING_CHARLENGTH, 1));
+        names.add(ff.functionName(STRING_CONCAT, 2));
+        names.add(ff.functionName(STRING_POSITION, 2));
+        names.add(ff.functionName(STRING_SUBSTIRNG, 3));
+
+        // register date functions
+        names.add(ff.functionName(DATE_CURRENT_TIME, 0));
+
+        // register numeric functions
+        names.add(ff.functionName(NUMERIC_ABS, 1));
+        names.add(ff.functionName(NUMERIC_CEILING, 1));
+        names.add(ff.functionName(NUMERIC_COS, 1));
+        names.add(ff.functionName(NUMERIC_CAST, 2));
+        names.add(ff.functionName(NUMERIC_FLOOR, 1));
+        names.add(ff.functionName(NUMERIC_LOG, 1));
+        names.add(ff.functionName(NUMERIC_LOG10, 1));
+        names.add(ff.functionName(NUMERIC_MOD, 2));
+        names.add(ff.functionName(NUMERIC_POWER, 2));
+        names.add(ff.functionName(NUMERIC_ROUND, 1));
+        names.add(ff.functionName(NUMERIC_SIN, 1));
+        names.add(ff.functionName(NUMERIC_TAN, 1));
+
+        functionNames = Collections.unmodifiableList(names);
+    }
+
+    public Function function(String name, List<Expression> args, Literal fallback) {
+        return function(new NameImpl(name), args, fallback);
+    }
+
+    @Override
+    public Function function(Name name, List<Expression> args, Literal fallback) {
+        Expression[] argsArray = args.toArray(new Expression[0]);
+
+        // return the ECQL equivalent function
+        Expression[] argsArray = args.toArray(new Expression[0]);
+        try {
+            // Get the method by name and parameter type
+            Method method =
+                    this.getClass()
+                            .getDeclaredMethod(name.toString().toUpperCase(), Expression[].class);
+            return (Function) method.invoke(this, new Object[] {argsArray});
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public List<FunctionName> getFunctionNames() {
+        return (functionNames != null && !functionNames.isEmpty())
+                ? functionNames
+                : Collections.emptyList();
+    }
+
+    private Function LOWER(Expression[] argsArray) {
+        // LOWER(<string>) -> strToLowerCase(<string>)
+        return ff.function("strToLowerCase", argsArray);
+    }
+
+    private Function UPPER(Expression[] argsArray) {
+        // UPPER(<string>) -> strToUpperCase(<string>)
+        return ff.function("strToUpperCase", argsArray);
+    }
+
+    private Function CHAR_LENGTH(Expression[] argsArray) {
+        // CHAR_LENGTH(<string>) -> strLength(<string>)
+        return ff.function("strLength", argsArray);
+    }
+
+    private Function CONCAT(Expression[] argsArray) {
+        // CONCAT(<string1>, <string2>) -> strConcat(<string1>, <string2>)
+        return ff.function("strConcat", argsArray);
+    }
+
+    private Function POSITION(Expression[] argsArray) {
+        // POSITION(<substring>, <string>) -> strIndexOf(<string>, <substring>)
+        // Need to reverse the arguments
+        // TODO: strIndexOf returns 0-based index, but POSITION is 1-based index
+        Expression[] reversedArgs = new Expression[] {argsArray[1], argsArray[0]};
+        return ff.function("strIndexOf", reversedArgs);
+    }
+
+    private Function SUBSTRING(Expression[] argsArray) {
+        // SUBSTRING(<string>, <start>, <length>) -> strSubstring(<string>, <start>, <end>)
+        // NOTE: SUBSTRING is 1-based, strSubstring is 0-based index.
+        // Need to convert the length to an end index
+        Expression startIndex = ff.subtract(argsArray[1], ff.literal(1));
+        Expression endIndex = ff.add(startIndex, argsArray[2]);
+        Expression[] newArgs = new Expression[] {argsArray[0], startIndex, endIndex};
+        return ff.function("strSubstring", newArgs);
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRFunctionFactory.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRFunctionFactory.java
@@ -110,7 +110,10 @@ public class GSRFunctionFactory implements FunctionFactory {
 
     @Override
     public Function function(Name name, List<Expression> args, Literal fallback) {
-        Expression[] argsArray = args.toArray(new Expression[0]);
+        // Return custom functions first
+        if (STRING_POSITION.equals(name)) {
+            return new GSRStrIndexOf(name, args, fallback);
+        }
 
         // return the ECQL equivalent function
         Expression[] argsArray = args.toArray(new Expression[0]);
@@ -150,14 +153,6 @@ public class GSRFunctionFactory implements FunctionFactory {
     private Function CONCAT(Expression[] argsArray) {
         // CONCAT(<string1>, <string2>) -> strConcat(<string1>, <string2>)
         return ff.function("strConcat", argsArray);
-    }
-
-    private Function POSITION(Expression[] argsArray) {
-        // POSITION(<substring>, <string>) -> strIndexOf(<string>, <substring>)
-        // Need to reverse the arguments
-        // TODO: strIndexOf returns 0-based index, but POSITION is 1-based index
-        Expression[] reversedArgs = new Expression[] {argsArray[1], argsArray[0]};
-        return ff.function("strIndexOf", reversedArgs);
     }
 
     private Function SUBSTRING(Expression[] argsArray) {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRFunctionFactory.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRFunctionFactory.java
@@ -48,8 +48,6 @@ public class GSRFunctionFactory implements FunctionFactory {
 
     static final Name NUMERIC_COS = new NameImpl("COS");
 
-    static final Name NUMERIC_CAST = new NameImpl("CAST");
-
     static final Name NUMERIC_FLOOR = new NameImpl("FLOOR");
 
     static final Name NUMERIC_LOG = new NameImpl("LOG");
@@ -59,8 +57,6 @@ public class GSRFunctionFactory implements FunctionFactory {
     static final Name NUMERIC_MOD = new NameImpl("MOD");
 
     static final Name NUMERIC_POWER = new NameImpl("POWER");
-
-    static final Name NUMERIC_ROUND = new NameImpl("ROUND");
 
     static final Name NUMERIC_SIN = new NameImpl("SIN");
 
@@ -91,13 +87,11 @@ public class GSRFunctionFactory implements FunctionFactory {
         names.add(ff.functionName(NUMERIC_ABS, 1));
         names.add(ff.functionName(NUMERIC_CEILING, 1));
         names.add(ff.functionName(NUMERIC_COS, 1));
-        names.add(ff.functionName(NUMERIC_CAST, 2));
         names.add(ff.functionName(NUMERIC_FLOOR, 1));
         names.add(ff.functionName(NUMERIC_LOG, 1));
         names.add(ff.functionName(NUMERIC_LOG10, 1));
         names.add(ff.functionName(NUMERIC_MOD, 2));
         names.add(ff.functionName(NUMERIC_POWER, 2));
-        names.add(ff.functionName(NUMERIC_ROUND, 1));
         names.add(ff.functionName(NUMERIC_SIN, 1));
         names.add(ff.functionName(NUMERIC_TAN, 1));
 
@@ -113,6 +107,8 @@ public class GSRFunctionFactory implements FunctionFactory {
         // Return custom functions first
         if (STRING_POSITION.equals(name)) {
             return new GSRStrIndexOf(name, args, fallback);
+        } else if (NUMERIC_LOG10.equals(name)) {
+            return new GSRLog10(name, args, fallback);
         }
 
         // return the ECQL equivalent function
@@ -163,5 +159,81 @@ public class GSRFunctionFactory implements FunctionFactory {
         Expression endIndex = ff.add(startIndex, argsArray[2]);
         Expression[] newArgs = new Expression[] {argsArray[0], startIndex, endIndex};
         return ff.function("strSubstring", newArgs);
+    }
+
+    private Function CURRENT_TIME(Expression[] argsArray) {
+        // CURRENT_TIME() -> now()
+        return ff.function("now", argsArray);
+    }
+
+    private Function ABS(Expression[] argsArray) {
+        // Check the type of the first argument in argsArray
+        if (argsArray.length > 0 && argsArray[0] != null) {
+            Object value = argsArray[0].evaluate(null);
+
+            if (value instanceof Integer) {
+                return ff.function("abs", argsArray);
+            } else if (value instanceof Long) {
+                return ff.function("abs_2", argsArray);
+            } else if (value instanceof Float) {
+                return ff.function("abs_3", argsArray);
+            } else if (value instanceof Double) {
+                return ff.function("abs_4", argsArray);
+            }
+        }
+
+        return ff.function("abs", argsArray);
+    }
+
+    private Function CEILING(Expression[] argsArray) {
+        // CEILING(<number>) -> ceil(<x>: double)
+        return ff.function("ceil", argsArray);
+    }
+
+    private Function COS(Expression[] argsArray) {
+        // COS(<number>) -> cos(<angle>: double)
+        return ff.function("cos", argsArray);
+    }
+
+    private Function FLOOR(Expression[] argsArray) {
+        // FLOOR(<number>) -> floor(<x>: double)
+        return ff.function("floor", argsArray);
+    }
+
+    private Function LOG(Expression[] argsArray) {
+        // LOG(<number>) -> log(<x>: double)
+        return ff.function("log", argsArray);
+    }
+
+    private Function MOD(Expression[] argsArray) {
+        // MOD(<number>, <n>) -> modulo(<x>: int, <y>: int) | IEEEremainder(<x>: double, <y>:
+        // double)
+        if (argsArray.length >= 2 && argsArray[0] != null && argsArray[1] != null) {
+            Object value1 = argsArray[0].evaluate(null);
+            Object value2 = argsArray[1].evaluate(null);
+            if (value1 instanceof Integer && value2 instanceof Integer) {
+                return ff.function("modulo", argsArray);
+            } else if (value1 instanceof Double || value2 instanceof Double) {
+                // If either value is a double, use IEEEremainder
+                return ff.function("IEEEremainder", argsArray);
+            }
+        }
+
+        return ff.function("modulo", argsArray);
+    }
+
+    private Function POWER(Expression[] argsArray) {
+        // POWER(<number>, <y>) -> pow(<base>: double, <exponent>: double)
+        return ff.function("pow", argsArray);
+    }
+
+    private Function SIN(Expression[] argsArray) {
+        // SIN(<number>) -> sin(<angle>: double)
+        return ff.function("sin", argsArray);
+    }
+
+    private Function TAN(Expression[] argsArray) {
+        // TAN(<number>) -> tan(<angle>: double)
+        return ff.function("tan", argsArray);
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRLog10.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRLog10.java
@@ -1,0 +1,41 @@
+package org.geoserver.gsr.function;
+
+import java.util.List;
+import org.geotools.filter.FunctionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.util.Converters;
+import org.geotools.util.factory.Hints;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Literal;
+
+/** LOG10(<number>): The base-10 logarithm of the specified number. */
+public class GSRLog10 extends FunctionImpl {
+
+    public GSRLog10(Name name, List<Expression> args, Literal fallback) {
+        functionName = new FunctionNameImpl(name, args.size());
+        setName(name.getLocalPart());
+        setFallbackValue(fallback);
+        setParameters(args);
+    }
+
+    @Override
+    public Object evaluate(Object object) {
+
+        Object arg0;
+
+        arg0 = getParameters().get(0).evaluate(object);
+
+        if (arg0 == null) {
+            return null;
+        }
+
+        arg0 = Converters.convert(arg0, Double.class, new Hints());
+        if (arg0 == null) {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function log argument #0 - expected type double");
+        }
+
+        return Math.log10((Double) arg0);
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRStrIndexOf.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/function/GSRStrIndexOf.java
@@ -1,0 +1,48 @@
+package org.geoserver.gsr.function;
+
+import java.util.List;
+import org.geotools.filter.FunctionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.filter.function.StaticGeometry;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Literal;
+
+/**
+ * POSITION(<substring>, <string>) -> strIndexOf(<string>, <substring>) GSR's strIndexOf returns
+ * 0-based index, but POSITION is 1-based index This custom class is needed to reverse the order of
+ * the arguments, and add the extra +1 to the result to match the 1-based index behavior of POSITION
+ * }
+ */
+public class GSRStrIndexOf extends FunctionImpl {
+
+    public GSRStrIndexOf(Name name, List<Expression> args, Literal fallback) {
+        functionName = new FunctionNameImpl(name, args.size());
+        setName(name.getLocalPart());
+        setFallbackValue(fallback);
+        setParameters(args);
+    }
+
+    @Override
+    public Object evaluate(Object object) {
+
+        String arg0;
+        String arg1;
+
+        try {
+            arg0 = getParameters().get(0).evaluate(object, String.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function strIndexOf argument #0 - expected type String");
+        }
+
+        try {
+            arg1 = getParameters().get(1).evaluate(object, String.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function strIndexOf argument #1 - expected type String");
+        }
+
+        return Integer.valueOf(StaticGeometry.strIndexOf(arg1, arg0) + 1);
+    }
+}

--- a/src/community/gsr/src/main/resources/META-INF/services/org.geotools.filter.FunctionFactory
+++ b/src/community/gsr/src/main/resources/META-INF/services/org.geotools.filter.FunctionFactory
@@ -1,0 +1,1 @@
+org.geoserver.gsr.function.GSRFunctionFactory

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
@@ -50,7 +50,7 @@ public class GSRFunctionFactoryTest extends ControllerTest {
                         query(
                                 "cite",
                                 0,
-                                "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=NAME=SUBSTRING(\'testCam+Stream\', 5, CHAR_LENGTH(\'Cam+Stream\'))"));
+                                "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=NAME=SUBSTRING(\'testCam+Stream\', POSITION(\'Cam+Stream\', \'testCam+Stream\'), CHAR_LENGTH(\'Cam+Stream\'))"));
         assertTrue(
                 "Request with valid where clause; returned " + result,
                 JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
@@ -13,6 +13,12 @@ public class GSRFunctionFactoryTest extends ControllerTest {
     }
 
     @Test
+    public void testBasicQuery() throws Exception {
+        String result = getAsString(query("cite", 0, "?f=json"));
+        System.out.println("GSRFunctionFactoryTest.testBasicQuery() result = " + result);
+    }
+
+    @Test
     public void testWhereLOWER() throws Exception {
         String result =
                 getAsString(
@@ -60,13 +66,78 @@ public class GSRFunctionFactoryTest extends ControllerTest {
 
     @Test
     public void testWhereCONCAT() throws Exception {
-        // Test LOWER()
         String result =
                 getAsString(
                         query(
                                 "cite",
                                 0,
                                 "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=NAME=CONCAT(\'Cam+\', \'Stream\')"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+    }
+
+    @Test
+    public void testWhereNUMERIC() throws Exception {
+        // ABS
+        String result =
+                getAsString(query("cite", 0, "?f=json&&where=CHAR_LENGTH(NAME)=ABS(-10.0)"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+
+        // CEILING
+        result = getAsString(query("cite", 0, "?f=json&&where=CHAR_LENGTH(NAME)=CEILING(9.7892)"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+
+        // LOG10 (Custom) \ POWER
+        result =
+                getAsString(
+                        query("cite", 0, "?f=json&&where=CHAR_LENGTH(NAME)=LOG10(POWER(10, 10))"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+
+        // COS \ SIN \ TAN
+        result =
+                getAsString(
+                        query("cite", 0, "?f=json&&where=CHAR_LENGTH(NAME)=COS(SIN(TAN(3.141)))"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+
+        // MOD
+        result = getAsString(query("cite", 0, "?f=json&&where=CHAR_LENGTH(NAME)=MOD(42, 16)"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+
+        // FLOOR
+        result = getAsString(query("cite", 0, "?f=json&&where=CHAR_LENGTH(NAME)=FLOOR(10.3232)"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+    }
+
+    @Test
+    public void testWhereDATE() throws Exception {
+        String result = getAsString(query("cite", 0, "?f=json&&where=NAME=CURRENT_TIME()"));
         assertTrue(
                 "Request with valid where clause; returned " + result,
                 JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
@@ -1,0 +1,76 @@
+package org.geoserver.gsr.controller.map;
+
+import static org.junit.Assert.assertTrue;
+
+import net.sf.json.JSONObject;
+import org.geoserver.gsr.JsonSchemaTest;
+import org.geoserver.gsr.controller.ControllerTest;
+import org.junit.Test;
+
+public class GSRFunctionFactoryTest extends ControllerTest {
+    private String query(String service, int layerId, String params) {
+        return getBaseURL() + service + "/Streams/FeatureServer/" + layerId + "/query" + params;
+    }
+
+    @Test
+    public void testWhereLOWER() throws Exception {
+        String result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=LOWER(NAME)=\'cam+stream\'"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+    }
+
+    @Test
+    public void testWhereUPPER() throws Exception {
+        String result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=UPPER(NAME)=\'CAM+STREAM\'"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+    }
+
+    @Test
+    public void testWhereSUBSTRING() throws Exception {
+        // Also tests POSITION and CHAR_LENGTH
+        String result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=NAME=SUBSTRING(\'testCam+Stream\', 5, CHAR_LENGTH(\'Cam+Stream\'))"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+    }
+
+    @Test
+    public void testWhereCONCAT() throws Exception {
+        // Test LOWER()
+        String result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&geometryType=esriGeometryEnvelope&geometry=-180,-90,180,90&where=NAME=CONCAT(\'Cam+\', \'Stream\')"));
+        assertTrue(
+                "Request with valid where clause; returned " + result,
+                JsonSchemaTest.validateJSON(result, "/gsr/1.0/featureSet.json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue("Request with short envelope; returned " + result, json.containsKey("features"));
+    }
+}


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

We've found that GSR doesn't support the same query syntax as Esri during `where` filters in Feature query requests.

For example, a request like this, which is typical from Esri while filtering, results in an 'invalid CQL' error:
```
/query?f=json&where=(1=1)%20AND%20LOWER(FIELD)=%test%27
```

The CQL source (i.e. `(1=1)%20AND%20LOWER(FIELD)=%test%27`) is parsed straight from the URL into creating a new `Filter`.

The `AbstractFilterBuilder` class then identifies in the source if there is a function to build. 
If there is, it will take the name of the function and see if that function name is registered in any of the `FunctionFactory` classes. ([Source](https://github.com/koordinates/geotools/blob/6a1de8f8ca614acaa6a21f3565e1a0eccaaaf1a8/modules/library/main/src/main/java/org/geotools/filter/FunctionFinder.java#L227-L233))

Basically this PR registers the names of the SQL functions in `GSRFunctionFactory` so that it can be found, and will then return their equivalent ECQL functions (will go through the function name search process again. These ECQL functions live in `GeoServerFunctionFactory`)

# Checklist

- [x] Unit tests

## List of functions to implement

### String Functions
| SQL | GSR |Notes | Implemented |
| --- | ----------- | --- | --- |
| `CHAR_LENGTH(<string>)` | `strLength(string: String)` |  |  &#9745; |
| `CONCAT(<string1>, <string2>)` | `strConcat(a: String, b: String)` |  |  &#9745; |
| `POSITION(<substring>, <string>)` | `strIndexOf(string: String, substring: String)` | SQL is 1-based index while GSR is 0-based |  &#9745; |
| `SUBSTRING(<string>, <start>, <length>)` | `strSubstring(string: String, begin: Integer, end: Integer)` | Note that SQL uses `length`, which is the number of characters, while GSR uses `end`, which is to mark the character at index `end-1` |  &#9745; |
| `TRIM(BOTH / LEADING / TRAILING ' ' FROM <string>)` | `strTrim(string: String)` | GSR is `BOTH` by default. No options to choose leading or trailing spaces |
| `UPPER(<string>)` | `strToUpperCase(string: String)` |  |  &#9745; |
| `LOWER(<string>)` | `strToLowerCase(string: String)` |  |  &#9745; |

---

### Date Functions
| SQL | GSR |Notes | Implemented |
| --- | ----------- | --- | --- |
| `CURRENT_DATE()` | N/A |
| `CURRENT_TIME()` | `now` |
| `CURRENT_TIMESTAMP()` | N/A | Unsure if `now` returns milliseconds | &#9745; |
| `EXTRACT(<unit> FROM <date>)` | N/A |

---
### Numeric Functions
| SQL | GSR |Notes | Implemented |
| --- | ----------- | --- | --- |
| `ABS(<number>)` | `abs, abs_2, abs_3, abs_4` |Different usages of `abs` depending on number type | &#9745; |
| `CEILING(<number>)` | `ceil(x: Double)` |  | &#9745; |
| `COS(<number>)` | `cos(angle: Double)` |  | &#9745; |
| `CAST(<number> AS FLOAT / INT)` | `(int)`, or `(double)` |eg. `(int)floor(a + 0.5)` |
| `FLOOR(<number>)` | `floor(x: Double)`|  |   &#9745; |
| `LOG(<number>)` | `log(x: Integer)` |  |  &#9745; |
| `LOG10(<number>)` | N/A | New GSRLog10 function |  &#9745; |
| `MOD(<number>, <n>)` | `IEEEremainder(x: Double, y: Double)` \ `modulo(x: int, y: int)`  |  |   &#9745; |
| `NULLIF(<number>, <value>)` | N/A |
| `POWER(<number> , <y>)` | `pow(base: Double, exponent: Double)`|  |  &#9745; |
| `ROUND(<number> , <length>)` | `round`, `round_2`, `round_double`|No option to specify the position/decimal points to round |
| `SIN(<number>)` | `sin(angle: Double)`|  |   &#9745; |
| `TAN(<number>)` | `tan(angle: Double)`|  |  &#9745; |
| `TRUNCATE(<number>,<decimal_place>)` | N/A|
