### PR TITLE
GSR: Support Query Pagination

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/GSRFeatureResultPBF.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/GSRFeatureResultPBF.java
@@ -56,7 +56,7 @@ public class GSRFeatureResultPBF {
 
     /**
      * FeatureResult consists of the following fields: objectIdFieldName, globalIdFieldName,
-     * geometryType, spatialReference, transform, fields, features
+     * geometryType, exceededTransferLimit, spatialReference, transform, fields, features
      *
      * @param flist
      * @return FeatureResult
@@ -68,6 +68,11 @@ public class GSRFeatureResultPBF {
         // OBJECTID Field and GlobalID Field
         featureRestBuilder.setObjectIdFieldName(flist.objectIdFieldName);
         featureRestBuilder.setGlobalIdFieldName(flist.globalIdFieldName);
+
+        // exceededTransferLimit
+        if (flist.exceededTransferLimit != null) {
+            featureRestBuilder.setExceededTransferLimit(flist.exceededTransferLimit);
+        }
 
         // Geometry Type
         if (flist.geometryType != null) {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -226,6 +226,8 @@ public class FeatureLayerController extends AbstractGSRController {
                         whereClause,
                         false,
                         null,
+                        0,
+                        null,
                         l);
         long[] ids = FeatureEncoder.objectIds(features).getObjectIds();
         List<Long> idsList = Arrays.stream(ids).boxed().collect(Collectors.toList());

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -173,6 +173,8 @@ public class FeatureServiceController extends QueryController {
                                     whereClause,
                                     returnGeometry,
                                     outFieldsText,
+                                    0,
+                                    null,
                                     l),
                             returnGeometry,
                             outSRText);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -207,6 +207,8 @@ public class MapServiceController extends AbstractGSRController {
                                                 null,
                                                 true,
                                                 null,
+                                                0,
+                                                null,
                                                 layer.layer);
 
                                 result.getResults()

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -83,7 +83,10 @@ public class QueryController extends AbstractGSRController {
             @RequestParam(name = "returnCountOnly", required = false, defaultValue = "false")
                     boolean returnCountOnly,
             @RequestParam(name = "quantizationParameters", required = false)
-                    String quantizationParameters)
+                    String quantizationParameters,
+            @RequestParam(name = "resultRecordCount", required = false) Integer resultRecordCount,
+            @RequestParam(name = "resultOffset", required = false, defaultValue = "0")
+                    Integer resultOffset)
             throws IOException {
 
         LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName, layerName);
@@ -110,6 +113,8 @@ public class QueryController extends AbstractGSRController {
                         whereClause,
                         returnGeometry,
                         outFieldsText,
+                        resultOffset,
+                        resultRecordCount,
                         layersAndTables);
         // returnCountOnly should take precedence over returnIdsOnly.
         // Sometimes both count and Ids are requested, but the count is expected in
@@ -121,7 +126,12 @@ public class QueryController extends AbstractGSRController {
         } else {
             FeatureList featureList =
                     new FeatureList(
-                            features, returnGeometry, outSRText, quantizationParameters, format);
+                            features,
+                            returnGeometry,
+                            outSRText,
+                            quantizationParameters,
+                            format,
+                            resultRecordCount);
             return featureList;
         }
     }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
@@ -12,7 +12,9 @@ package org.geoserver.gsr.model.feature;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
@@ -39,12 +41,19 @@ public class FeatureLayer extends AbstractLayerOrTable {
     // supportsStatistics - may be able to implement with aggregate functions
     protected Boolean supportsStatistics = false;
     // supportsAdvancedQueries - not implemented yet (no queries at all.) implement using SortBy
-    protected Boolean supportsAdvancedQueries = false;
-    // supportsCoordinatesQuantization - Supported (See QuantizedGeometryEncoder), but breaks ArcPRO usage.
+    protected Boolean supportsAdvancedQueries = true;
+    protected Map<String, Object> advancedQueryCapabilities =
+            Collections.singletonMap("supportsPagination", true);
+    // supportsCoordinatesQuantization - Supported (See QuantizedGeometryEncoder), but breaks ArcPRO
+    // usage.
     protected Boolean supportsCoordinatesQuantization = false;
     // supportedQueryFormats - JSON and PBF
     protected String supportedQueryFormats = "JSON,geojson,PBF";
     protected String supportedPbfFeatureEncodings = "esriDefault";
+
+    // feature query pagination
+    protected Integer maxRecordCount = 30000;
+    protected Integer maxRecordCountFactor = 1;
 
     // enableZDefaults - ignore
     // zDefault - ignore
@@ -109,6 +118,18 @@ public class FeatureLayer extends AbstractLayerOrTable {
 
     public Boolean getSupportsAdvancedQueries() {
         return supportsAdvancedQueries;
+    }
+
+    public Map<String, Object> getAdvancedQueryCapabilities() {
+        return advancedQueryCapabilities;
+    }
+
+    public Integer getMaxRecordCount() {
+        return maxRecordCount;
+    }
+
+    public Integer getMaxRecordCountFactor() {
+        return maxRecordCountFactor;
     }
 
     public String getSupportedQueryFormats() {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureList.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureList.java
@@ -57,6 +57,8 @@ public class FeatureList implements GSRModel {
 
     public final Transform transform;
 
+    public final Boolean exceededTransferLimit;
+
     public final ArrayList<Field> fields = new ArrayList<>();
 
     public final ArrayList<Feature> features = new ArrayList<>();
@@ -69,7 +71,7 @@ public class FeatureList implements GSRModel {
     public <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureList(
             FeatureCollection<T, F> collection, boolean returnGeometry, String outputSR)
             throws IOException {
-        this(collection, returnGeometry, outputSR, null, null);
+        this(collection, returnGeometry, outputSR, null, null, null);
     }
 
     public <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureList(
@@ -77,7 +79,8 @@ public class FeatureList implements GSRModel {
             boolean returnGeometry,
             String outputSR,
             String quantizationParameters,
-            String format)
+            String format,
+            Integer resultRecordCount)
             throws IOException {
 
         T schema = collection.getSchema();
@@ -209,6 +212,12 @@ public class FeatureList implements GSRModel {
                                 spatialReference,
                                 objectIdFieldName,
                                 geometryEncoder));
+            }
+            if ((resultRecordCount == null)
+                    || (resultRecordCount != null && features.size() < resultRecordCount)) {
+                exceededTransferLimit = false;
+            } else {
+                exceededTransferLimit = true;
             }
         }
     }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
@@ -27,6 +27,7 @@ import org.geoserver.gsr.model.exception.FeatureServiceErrors;
 import org.geoserver.gsr.model.exception.ServiceError;
 import org.geoserver.gsr.model.feature.EditResult;
 import org.geoserver.gsr.model.feature.EditResults;
+import org.geoserver.gsr.model.feature.FeatureLayer;
 import org.geoserver.gsr.model.geometry.SpatialReference;
 import org.geoserver.gsr.model.geometry.SpatialRelationship;
 import org.geoserver.gsr.model.map.LayerOrTable;
@@ -653,9 +654,12 @@ public class FeatureDAO {
                     throws IOException {
 
         LayerInfo l = null;
+        LayerOrTable foundLayerOrTable = null;
+
         for (LayerOrTable layerOrTable : layersAndTables.layers) {
             if (Objects.equals(layerOrTable.getId(), layerId)) {
                 l = layerOrTable.layer;
+                foundLayerOrTable = layerOrTable;
                 break;
             }
         }
@@ -664,6 +668,7 @@ public class FeatureDAO {
             for (LayerOrTable layerOrTable : layersAndTables.tables) {
                 if (Objects.equals(layerOrTable.getId(), layerId)) {
                     l = layerOrTable.layer;
+                    foundLayerOrTable = layerOrTable;
                     break;
                 }
             }
@@ -672,6 +677,11 @@ public class FeatureDAO {
         if (null == l) {
             throw new NoSuchElementException(
                     "No table or layer in workspace \"" + workspaceName + " for id " + layerId);
+        }
+
+        FeatureLayer featureLayer = new FeatureLayer(foundLayerOrTable);
+        if (resultRecordCount == null || resultRecordCount > featureLayer.getMaxRecordCount()) {
+            resultRecordCount = featureLayer.getMaxRecordCount();
         }
 
         return getFeatureCollectionForLayer(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
@@ -647,6 +647,8 @@ public class FeatureDAO {
                     String whereClause,
                     Boolean returnGeometry,
                     String outFieldsText,
+                    Integer resultOffset,
+                    Integer resultRecordCount,
                     LayersAndTables layersAndTables)
                     throws IOException {
 
@@ -688,6 +690,8 @@ public class FeatureDAO {
                 whereClause,
                 returnGeometry,
                 outFieldsText,
+                resultOffset,
+                resultRecordCount,
                 l);
     }
 
@@ -744,6 +748,8 @@ public class FeatureDAO {
                     String whereClause,
                     Boolean returnGeometry,
                     String outFieldsText,
+                    Integer resultOffset,
+                    Integer resultRecordCount,
                     LayerInfo l)
                     throws IOException {
         FeatureTypeInfo featureType = (FeatureTypeInfo) l.getResource();
@@ -789,6 +795,11 @@ public class FeatureDAO {
             query = new Query(featureType.getName(), filter, effectiveProperties);
         }
         query.setCoordinateSystemReproject(outSR);
+
+        if (resultRecordCount != null) {
+            query.setStartIndex(resultOffset);
+            query.setMaxFeatures(resultRecordCount);
+        }
 
         return source.getFeatures(query);
     }

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -551,6 +551,30 @@ public class QueryControllerTest extends ControllerTest {
     }
 
     @Test
+    public void testQueryPagination() throws Exception {
+        String result = getAsString(query("cite", 0, "?f=json&resultOffset=0&resultRecordCount=1"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        JSONArray features = json.getJSONArray("features");
+        assertEquals(1, features.size());
+        assert (json.getBoolean("exceededTransferLimit") == true);
+
+        result = getAsString(query("cite", 0, "?f=json&resultOffset=1&resultRecordCount=1"));
+        json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        features = json.getJSONArray("features");
+        assertEquals(1, features.size());
+        assert (json.getBoolean("exceededTransferLimit") == true);
+
+        result = getAsString(query("cite", 0, "?f=json&resultOffset=2&resultRecordCount=1"));
+        json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        features = json.getJSONArray("features");
+        assertEquals(0, features.size());
+        assert (json.getBoolean("exceededTransferLimit") == false);
+    }
+
+    @Test
     public void testBasicQuery() throws Exception {
         String query =
                 getBaseURL()


### PR DESCRIPTION
**Note: New flags**
Ref: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#typedefinitions-summary
- `supportsPagination`: Indicates if the query response supports pagination.
- `maxRecordCount`: The maximum number of records that will be returned for a given query. Set to 30000
- `maxRecordCountFactor` ([Ref](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#maxRecordCountFactor)): When set, the maximum number of features returned by the query will equal the maxRecordCount of the service multiplied by this factor. The value of this property may not exceed 5.

**QueryController** must now take `resultOffset` and `resultRecordCount` query parameters. 
Ref: https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
- `resultOffset`: This option can be used for fetching query results by skipping the specified number of records and starting from the next record (that is, `resultOffset` + 1). The default is 0 . This parameter only applies if `supportsPagination` is true . You can use this option to fetch records that are beyond `maxRecordCount` .
- `resultRecordCount`: This option can be used for fetching query results up to the `resultRecordCount` specified. When `resultOffset` is specified but this parameter is not, the map service defaults it to `maxRecordCount`. The maximum value for this parameter is the value of the layer's `maxRecordCount` property. The minimum value entered for this parameter cannot be below 1. This parameter only applies if `supportsPagination` is true .
