### PR TITLE
GSR: Support sorting by fields & distinct values

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -225,8 +225,10 @@ public class FeatureLayerController extends AbstractGSRController {
                         null,
                         whereClause,
                         false,
+                        false,
                         null,
                         0,
+                        null,
                         null,
                         l);
         long[] ids = FeatureEncoder.objectIds(features).getObjectIds();

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -136,7 +136,8 @@ public class FeatureServiceController extends QueryController {
             @RequestParam(name = "outFields", required = false, defaultValue = "*")
                     String outFieldsText,
             @RequestParam(name = "returnIdsOnly", required = false, defaultValue = "false")
-                    boolean returnIdsOnly)
+                    boolean returnIdsOnly,
+            @RequestParam(name = "orderByFields", required = false) String orderByFieldsText)
             throws IOException {
         LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName, layerName);
         if (layersAndTables.layers.size() == 0 & layersAndTables.tables.size() == 0) {
@@ -172,9 +173,11 @@ public class FeatureServiceController extends QueryController {
                                     maxAllowableOffsets,
                                     whereClause,
                                     returnGeometry,
+                                    false,
                                     outFieldsText,
                                     0,
                                     null,
+                                    orderByFieldsText,
                                     l),
                             returnGeometry,
                             outSRText);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -206,8 +206,10 @@ public class MapServiceController extends AbstractGSRController {
                                                 null,
                                                 null,
                                                 true,
+                                                false,
                                                 null,
                                                 0,
+                                                null,
                                                 null,
                                                 layer.layer);
 

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
@@ -12,7 +12,7 @@ package org.geoserver.gsr.model.feature;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -42,8 +42,13 @@ public class FeatureLayer extends AbstractLayerOrTable {
     protected Boolean supportsStatistics = false;
     // supportsAdvancedQueries - not implemented yet (no queries at all.) implement using SortBy
     protected Boolean supportsAdvancedQueries = true;
-    protected Map<String, Object> advancedQueryCapabilities =
-            Collections.singletonMap("supportsPagination", true);
+    protected Map<String, Object> advancedQueryCapabilities = new HashMap<>();
+
+    {
+        advancedQueryCapabilities.put("supportsPagination", true);
+        advancedQueryCapabilities.put("supportsOrderBy", true);
+        advancedQueryCapabilities.put("supportsDistinct", true);
+    }
     // supportsCoordinatesQuantization - Supported (See QuantizedGeometryEncoder), but breaks ArcPRO
     // usage.
     protected Boolean supportsCoordinatesQuantization = false;

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
@@ -804,8 +804,7 @@ public class FeatureDAO {
 
         FeatureSource<? extends FeatureType, ? extends Feature> source =
                 featureType.getFeatureSource(null, null);
-        final String[] effectiveProperties =
-                adjustProperties(returnGeometry, properties, source.getSchema());
+        final String[] effectiveProperties = adjustProperties(true, properties, source.getSchema());
 
         final Query query;
         if (effectiveProperties == null) {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
@@ -188,6 +188,20 @@ public class FeatureEncoder {
                 OBJECTID_FIELD_NAME, objectIds.stream().mapToLong(i -> i).toArray());
     }
 
+    public static <T extends FeatureType, F extends org.opengis.feature.Feature>
+            FeatureIdSet objectIds(FeatureList flist) {
+
+        // TODO: Advertise "real" identifier property
+
+        List<Long> objectIds = new ArrayList<>();
+        for (Feature feature : flist.features) {
+            Map<String, Object> attributes = feature.getAttributes();
+            objectIds.add((Long) attributes.get(OBJECTID_FIELD_NAME));
+        }
+        return new FeatureIdSet(
+                OBJECTID_FIELD_NAME, objectIds.stream().mapToLong(i -> i).toArray());
+    }
+
     public static final Pattern FEATURE_ID_PATTERN = Pattern.compile("(^(?:.*\\.)?)(\\p{Digit}+)$");
 
     /**
@@ -273,6 +287,12 @@ public class FeatureEncoder {
     public static <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureCount count(
             FeatureCollection<T, F> features) {
         int count = features.size();
+        return new FeatureCount(count);
+    }
+
+    public static <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureCount count(
+            FeatureList flist) {
+        int count = flist.features.size();
         return new FeatureCount(count);
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/ObjectIdRemappingFilterVisitor.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/ObjectIdRemappingFilterVisitor.java
@@ -16,7 +16,9 @@ import org.geotools.filter.visitor.DuplicatingFilterVisitor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.Id;
+import org.opengis.filter.Not;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.identity.FeatureId;
@@ -69,6 +71,17 @@ public class ObjectIdRemappingFilterVisitor extends DuplicatingFilterVisitor {
         }
 
         return getFactory(extraData).equal(expr1, expr2, matchCase, filter.getMatchAction());
+    }
+
+    @Override
+    public Object visit(Not filter, Object extraData) {
+        if (filter.getFilter() instanceof PropertyIsNull) {
+            Expression expr = ((PropertyIsNull) filter.getFilter()).getExpression();
+            if (isIdAttribute(expr, false)) {
+                return Filter.INCLUDE;
+            }
+        }
+        return getFactory(extraData).not((Filter) filter.getFilter().accept(this, extraData));
     }
 
     private boolean isIdAttribute(Expression expr, boolean matchCase) {

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -575,6 +575,59 @@ public class QueryControllerTest extends ControllerTest {
     }
 
     @Test
+    public void testQueryOrderByFields() throws Exception {
+        // default order is ascending
+        String result = getAsString(query("cite", 0, "?f=json&orderByFields=objectid"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        JSONArray features = json.getJSONArray("features");
+        assertEquals(2, features.size());
+        Long firstId = features.getJSONObject(0).getJSONObject("attributes").getLong("objectid");
+        assert (firstId == 1107532066140L);
+
+        // test descending order
+        result = getAsString(query("cite", 0, "?f=json&orderByFields=objectid DESC"));
+        json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        features = json.getJSONArray("features");
+        assertEquals(2, features.size());
+        firstId = features.getJSONObject(0).getJSONObject("attributes").getLong("objectid");
+        assert (firstId == 1107532066141L);
+    }
+
+    @Test
+    public void testQueryReturnDistinctValues() throws Exception {
+        // can't have returnGeometry and returnDistinctValues at the same time
+        String result =
+                getAsString(
+                        query("cite", 0, "?f=json&returnGeometry=true&returnDistinctValues=true"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue(json.has("error"));
+
+        // two outFields is not yet supported with returnDistinctValues
+        result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&outFields=NAME,FID&returnGeometry=false&returnDistinctValues=true"));
+        json = JSONObject.fromObject(result);
+        assertTrue(json.has("error"));
+
+        result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&outFields=NAME&returnGeometry=false&returnDistinctValues=true"));
+        json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        JSONArray features = json.getJSONArray("features");
+        assertEquals(2, features.size());
+        assertFalse(features.getJSONObject(0).has("geometry"));
+    }
+
+    @Test
     public void testBasicQuery() throws Exception {
         String query =
                 getBaseURL()

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -364,6 +364,10 @@ public class QueryControllerTest extends ControllerTest {
                     "Found geometry at index " + i + " in " + result,
                     !feature.containsKey("geometry"));
         }
+        JSONArray fields = json.getJSONArray("fields");
+        assertEquals("Should have two fields [objectid and NAME]", 2, fields.size());
+        assertTrue(fields.getJSONObject(0).getString("name").equals("NAME"));
+        assertTrue(fields.getJSONObject(1).getString("name").equals("objectid"));
     }
 
     @Test


### PR DESCRIPTION
**Note: New flags**
Ref: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#typedefinitions-summary
- `supportsOrderBy`: Indicates if features returned in the query response can be ordered by one or more fields.
- `supportsDistinct`: Indicates if the layer supports queries for distinct values based on fields specified in the [`outFields`](https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#outFields).

**QueryController** now takes `orderByFields (string[])` and `returnDistinctValue (boolean)` query parameters. 
Ref: https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
- `returnDistinctValues`: If true then the query returns distinct values based on the field(s) specified in [`outFields`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#outFields).
    - Note that [`returnGeometry`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#returnGeometry) must be false when `returnDistinctValues` is true. 
    - Currently, only one field in `outFields` is supported. `UniqueVisitor` doesn't have the option to support multiple properties in the current version of geotools.
    - if `outFields` contains the `objectid` field, don't do anything. `objectid` is already unique.

- `orderByFields`: One or more field names used to order the query results. Specify ASC (ascending) or DESC (descending) after the field name to control the order. The default order is ASC.
