### PR TITLE
GSR: Support Basic Statistical Queries

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -230,6 +230,7 @@ public class FeatureLayerController extends AbstractGSRController {
                         0,
                         null,
                         null,
+                        null,
                         l);
         long[] ids = FeatureEncoder.objectIds(features).getObjectIds();
         List<Long> idsList = Arrays.stream(ids).boxed().collect(Collectors.toList());

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -178,6 +178,7 @@ public class FeatureServiceController extends QueryController {
                                     0,
                                     null,
                                     orderByFieldsText,
+                                    null,
                                     l),
                             returnGeometry,
                             outSRText);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -211,6 +211,7 @@ public class MapServiceController extends AbstractGSRController {
                                                 0,
                                                 null,
                                                 null,
+                                                null,
                                                 layer.layer);
 
                                 result.getResults()

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -131,6 +131,7 @@ public class QueryController extends AbstractGSRController {
                         resultOffset,
                         resultRecordCount,
                         orderByFieldsText,
+                        outStatistics,
                         layersAndTables);
 
         if (groupByFieldsForStatistics != null && outStatistics != null) {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -15,6 +15,7 @@ import org.geoserver.gsr.api.AbstractGSRController;
 import org.geoserver.gsr.api.GSRProtobufConverter;
 import org.geoserver.gsr.model.GSRModel;
 import org.geoserver.gsr.model.feature.FeatureList;
+import org.geoserver.gsr.model.feature.FeatureStatistics;
 import org.geoserver.gsr.model.map.LayersAndTables;
 import org.geoserver.gsr.translate.feature.FeatureDAO;
 import org.geoserver.gsr.translate.feature.FeatureEncoder;
@@ -89,7 +90,10 @@ public class QueryController extends AbstractGSRController {
             @RequestParam(name = "resultRecordCount", required = false) Integer resultRecordCount,
             @RequestParam(name = "resultOffset", required = false, defaultValue = "0")
                     Integer resultOffset,
-            @RequestParam(name = "orderByFields", required = false) String orderByFieldsText)
+            @RequestParam(name = "orderByFields", required = false) String orderByFieldsText,
+            @RequestParam(name = "groupByFieldsForStatistics", required = false)
+                    String groupByFieldsForStatistics,
+            @RequestParam(name = "outStatistics", required = false) String outStatistics)
             throws IOException {
 
         if (returnDistinctValues && returnGeometry) {
@@ -128,6 +132,10 @@ public class QueryController extends AbstractGSRController {
                         resultRecordCount,
                         orderByFieldsText,
                         layersAndTables);
+
+        if (groupByFieldsForStatistics != null && outStatistics != null) {
+            return new FeatureStatistics(features, groupByFieldsForStatistics, outStatistics);
+        }
 
         FeatureList featureList =
                 new FeatureList(

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
@@ -38,8 +38,7 @@ public class FeatureLayer extends AbstractLayerOrTable {
     protected Boolean syncCanReturnChanges = false;
     // supportsRollbackOnFailureParameter - supported
     protected Boolean supportsRollbackOnFailureParameter = true;
-    // supportsStatistics - may be able to implement with aggregate functions
-    protected Boolean supportsStatistics = false;
+    protected Boolean supportsStatistics = true;
     // supportsAdvancedQueries - not implemented yet (no queries at all.) implement using SortBy
     protected Boolean supportsAdvancedQueries = true;
     protected Map<String, Object> advancedQueryCapabilities = new HashMap<>();

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureStatistics.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureStatistics.java
@@ -1,0 +1,138 @@
+package org.geoserver.gsr.model.feature;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.sf.json.*;
+import org.geoserver.gsr.model.GSRModel;
+import org.geoserver.gsr.model.geometry.*;
+import org.geoserver.gsr.translate.feature.FeatureEncoder;
+import org.geoserver.ogcapi.APIException;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.visitor.Aggregate;
+import org.geotools.feature.visitor.GroupByVisitor;
+import org.geotools.feature.visitor.GroupByVisitorBuilder;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.PropertyDescriptor;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.PropertyName;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Statistics List of {@link org.geoserver.gsr.model.feature.Feature}, that can be serialized as
+ * JSON
+ *
+ * <p>See https://developers.arcgis.com/documentation/common-data-types/featureset-object.htm
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FeatureStatistics implements GSRModel {
+
+    public final String displayFieldName = "";
+
+    public final Map<String, String> fieldAliases = new HashMap<>();
+
+    public final ArrayList<Field> fields = new ArrayList<>();
+
+    public final ArrayList<Feature> features = new ArrayList<>();
+
+    public <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureStatistics(
+            FeatureCollection<T, F> collection,
+            String groupByFieldsForStatistics,
+            String outStatistics)
+            throws IOException {
+
+        T schema = collection.getSchema();
+
+        // Parse the string into a JSON array
+        JSON json = JSONSerializer.toJSON(outStatistics);
+        JSONArray jsonArray = (JSONArray) json;
+        String onStatisticField = jsonArray.getJSONObject(0).getString("onStatisticField");
+        String outStatisticFieldName =
+                jsonArray.getJSONObject(0).getString("outStatisticFieldName");
+        StatisticTypeEnum statisticType =
+                StatisticTypeEnum.fromValue(jsonArray.getJSONObject(0).getString("statisticType"));
+
+        if (!onStatisticField.equals(groupByFieldsForStatistics)) {
+            throw new APIException(
+                    "InvalidOperation",
+                    "Cannot perform operation on the given feature collection. "
+                            + "groupByFieldsForStatistics must be the same as onStatisticField.",
+                    HttpStatus.BAD_REQUEST);
+        }
+
+        // Add the fields to the response
+        for (PropertyDescriptor desc : schema.getDescriptors()) {
+            if (schema.getGeometryDescriptor() != null
+                    && !desc.getName().equals(schema.getGeometryDescriptor().getName())
+                    && desc.getName().toString().equals(onStatisticField)) {
+                fields.add(FeatureEncoder.field(desc, null));
+            }
+        }
+        fields.add(new Field(outStatisticFieldName, FieldTypeEnum.DOUBLE, outStatisticFieldName));
+
+        fieldAliases.put(onStatisticField, onStatisticField);
+        fieldAliases.put(outStatisticFieldName, outStatisticFieldName);
+
+        FilterFactory factory = CommonFactoryFinder.getFilterFactory(null);
+        PropertyName expr = factory.property(onStatisticField);
+        GroupByVisitor visitor;
+        switch (statisticType) {
+            case COUNT:
+                visitor = groupVisitor(expr, Aggregate.COUNT);
+                break;
+            case SUM:
+                visitor = groupVisitor(expr, Aggregate.SUM);
+                break;
+            case MIN:
+                visitor = groupVisitor(expr, Aggregate.MIN);
+                break;
+            case MAX:
+                visitor = groupVisitor(expr, Aggregate.MAX);
+                break;
+            case AVERAGE:
+                visitor = groupVisitor(expr, Aggregate.AVERAGE);
+                break;
+            case STD_DEV:
+                visitor = groupVisitor(expr, Aggregate.STD_DEV);
+                break;
+            default:
+                throw new APIException(
+                        "InvalidStatisticType",
+                        "Statistic type not supported: " + statisticType.value(),
+                        HttpStatus.BAD_REQUEST);
+        }
+        try {
+            collection.accepts(visitor, null);
+        } catch (IOException e) {
+            throw new APIException(
+                    "InvalidOperation",
+                    "Cannot perform operation on the given feature collection. " + e.getMessage(),
+                    HttpStatus.BAD_REQUEST);
+        }
+        Map<String, Object> attributes;
+        Map<List<Object>, Object> groupResult = visitor.getResult().toMap();
+
+        for (Map.Entry<List<Object>, Object> entry : groupResult.entrySet()) {
+            List<Object> key = entry.getKey();
+            Object value = entry.getValue();
+
+            attributes = new HashMap<>();
+            attributes.put(onStatisticField, key.get(0));
+            attributes.put(outStatisticFieldName, value);
+
+            features.add(new Feature(null, attributes));
+        }
+    }
+
+    private GroupByVisitor groupVisitor(PropertyName propName, Aggregate agg) throws IOException {
+        GroupByVisitorBuilder builder = new GroupByVisitorBuilder();
+        builder.withAggregateVisitor(agg);
+        builder.withGroupByAttribute(propName);
+        builder.withAggregateAttribute(propName);
+        return builder.build();
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/StatisticTypeEnum.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/StatisticTypeEnum.java
@@ -1,0 +1,36 @@
+package org.geoserver.gsr.model.feature;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum StatisticTypeEnum {
+    COUNT("count"),
+    SUM("sum"),
+    MIN("min"),
+    MAX("max"),
+    AVERAGE("avg"),
+    STD_DEV("stddev");
+
+    private final String statisticType;
+
+    public String getStatisticType() {
+        return statisticType;
+    }
+
+    StatisticTypeEnum(String statType) {
+        this.statisticType = statType;
+    }
+
+    public static StatisticTypeEnum fromValue(String value) {
+        for (StatisticTypeEnum type : StatisticTypeEnum.values()) {
+            if (type.statisticType.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown statistic type: " + value);
+    }
+
+    @JsonValue
+    public String value() {
+        return this.statisticType;
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
@@ -656,6 +656,7 @@ public class FeatureDAO {
                     Integer resultOffset,
                     Integer resultRecordCount,
                     String orderByFieldsText,
+                    String outStatistics,
                     LayersAndTables layersAndTables)
                     throws IOException {
 
@@ -710,6 +711,7 @@ public class FeatureDAO {
                 resultOffset,
                 resultRecordCount,
                 orderByFieldsText,
+                outStatistics,
                 l);
     }
 
@@ -770,6 +772,7 @@ public class FeatureDAO {
                     Integer resultOffset,
                     Integer resultRecordCount,
                     String orderByFieldsText,
+                    String outStatistics,
                     LayerInfo l)
                     throws IOException {
         FeatureTypeInfo featureType = (FeatureTypeInfo) l.getResource();
@@ -816,8 +819,8 @@ public class FeatureDAO {
         }
         query.setCoordinateSystemReproject(outSR);
 
-        if (resultRecordCount != null && !returnDistinctValues) {
-            // If returnDistinctValues is true, we don't want to limit the number of records
+        if (resultRecordCount != null && !returnDistinctValues & outStatistics != null) {
+            // If returnDistinctValues/statistical query is true, we don't want to limit the number of records
             query.setStartIndex(resultOffset);
             query.setMaxFeatures(resultRecordCount);
         }

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -632,6 +632,27 @@ public class QueryControllerTest extends ControllerTest {
     }
 
     @Test
+    public void testStatisticsQuery() throws Exception {
+        String result =
+                getAsString(
+                        query(
+                                "cite",
+                                0,
+                                "?f=json&groupByFieldsForStatistics=NAME&outFields=*&outStatistics=[{\"onStatisticField\":\"NAME\",\"outStatisticFieldName\":\"countOFNAME\",\"statisticType\":\"count\"}]"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertFalse(json.has("error"));
+        JSONArray fields = json.getJSONArray("fields");
+        assertEquals(2, fields.size());
+        assertEquals("NAME", fields.getJSONObject(0).getString("name"));
+        assertEquals("countOFNAME", fields.getJSONObject(1).getString("name"));
+
+        JSONArray features = json.getJSONArray("features");
+        assertEquals(2, features.size());
+        assertEquals(
+                1, features.getJSONObject(0).getJSONObject("attributes").getInt("countOFNAME"));
+    }
+
+    @Test
     public void testBasicQuery() throws Exception {
         String query =
                 getBaseURL()


### PR DESCRIPTION
**Note: New flags**
Ref: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#typedefinitions-summary
- `supportsStatistics`: Indicates if the layer supports field-based statistical functions.

**QueryController** now takes `outStatistics (Object[])` and `groupByFieldsForStatistics (String[])` query parameters. 
- [`outStatistics`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#outStatistics): The definitions for one or more field-based statistics to be calculated. If outStatistics is specified the only other query parameters that should be used are [`groupByFieldsForStatistics`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#groupByFieldsForStatistics), [`orderByFields`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#orderByFields), [text](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#text), and [`where`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#where).

- `groupByFieldsForStatistics`: Used only in [statistical queries](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#statistic). When one or more field names are provided in this property, the output statistics will be grouped based on unique values from those fields. This is only valid when [`outStatistics`](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-Query.html#outStatistics) has been defined.

The statistical query type (eg. `sum`, `count`...) are outlined here: https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-StatisticDefinition.html#statisticType

We can achieve this in GSR using `GroupByVisitor`
- This takes in an `Aggregate` class. 
    - `Aggregate` class already has some of the key operations.
    - It doesn't have all, so the ones in this PR are only the ones that `Aggregate` supports. 
