### PR TITLE
Handle WFS 2.0 `GetFeatureType` Requests in Monitor Callback

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/MonitorCallback.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/MonitorCallback.java
@@ -20,6 +20,7 @@ import org.geoserver.monitor.ows.wfs.DescribeFeatureTypeHandler;
 import org.geoserver.monitor.ows.wfs.GetFeatureHandler;
 import org.geoserver.monitor.ows.wfs.LockFeatureHandler;
 import org.geoserver.monitor.ows.wfs.TransactionHandler;
+import org.geoserver.monitor.ows.wfs20.GetFeature20Handler;
 import org.geoserver.monitor.ows.wms.GetFeatureInfoHandler;
 import org.geoserver.monitor.ows.wms.GetLegendGraphicHandler;
 import org.geoserver.monitor.ows.wms.GetMapHandler;
@@ -46,6 +47,7 @@ public class MonitorCallback implements DispatcherCallback, ExtensionPriority {
         handlers.add(new GetFeatureHandler(monitor.getConfig(), catalog));
         handlers.add(new LockFeatureHandler(monitor.getConfig(), catalog));
         handlers.add(new TransactionHandler(monitor.getConfig(), catalog));
+        handlers.add(new GetFeature20Handler(monitor.getConfig(), catalog));
 
         // wms
         handlers.add(new GetFeatureInfoHandler(monitor.getConfig()));

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/wfs20/GetFeature20Handler.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/wfs20/GetFeature20Handler.java
@@ -1,0 +1,61 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.monitor.ows.wfs20;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.namespace.QName;
+import org.eclipse.emf.ecore.EObject;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.monitor.MonitorConfig;
+import org.geoserver.monitor.ows.wfs.WFSRequestObjectHandler;
+import org.geoserver.ows.util.OwsUtils;
+import org.geotools.xsd.EMFUtils;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+public class GetFeature20Handler extends WFSRequestObjectHandler {
+
+    public GetFeature20Handler(MonitorConfig config, Catalog catalog) {
+        super("net.opengis.wfs20.GetFeatureType", config, catalog);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<String> getLayers(Object request) {
+        List<Object> queries =
+                (List<Object>) EMFUtils.get((EObject) request, "abstractQueryExpression");
+        if (queries == null) {
+            return null;
+        }
+
+        List<String> layers = new ArrayList<>();
+        for (Object q : queries) {
+            List<Object> typeNames = (List<Object>) EMFUtils.get((EObject) q, "typeNames");
+
+            for (Object o : typeNames) {
+                layers.add(toString(o));
+            }
+        }
+        return layers;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected List<Object> getElements(Object request) {
+        return (List<Object>) OwsUtils.get(request, "abstractQueryExpression");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected CoordinateReferenceSystem getCrsFromElement(Object element) {
+        List<Object> types = (List<Object>) OwsUtils.get(element, "typeNames");
+        if (types.size() == 1) {
+            return crsFromTypeName((QName) types.get(0));
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/ows/MonitorCallbackTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/ows/MonitorCallbackTest.java
@@ -34,6 +34,7 @@ import net.opengis.wfs.QueryType;
 import net.opengis.wfs.TransactionType;
 import net.opengis.wfs.UpdateElementType;
 import net.opengis.wfs.WfsFactory;
+import net.opengis.wfs20.Wfs20Factory;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -202,6 +203,35 @@ public class MonitorCallbackTest {
         q.setFilter(f2);
 
         Operation op = op("GetFeature", "WFS", "1.0.0", gf);
+        callback.operationDispatched(new Request(), op);
+
+        assertEquals("acme:foo", data.getResources().get(0));
+        assertEquals("acme:bar", data.getResources().get(1));
+        BoundingBox expected =
+                new ReferencedEnvelope(53.73, 40, -60, -95.1193, CRS.decode("EPSG:4326"));
+        // xMin,yMin -95.1193,40 : xMax,yMax -60,53.73
+        BBoxAsserts.assertEqualsBbox(expected, data.getBbox(), 0.01);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked") // EMF mode without generics
+    public void testWFSGetFeature20() throws Exception {
+        net.opengis.wfs20.GetFeatureType gf = Wfs20Factory.eINSTANCE.createGetFeatureType();
+        org.opengis.filter.Filter f1 = parseFilter("BBOX(the_geom, 40, -90, 45, -60)");
+        org.opengis.filter.Filter f2 =
+                parseFilter("BBOX(the_geom, 5988504.35,851278.90, 7585113.55,1950872.01)");
+        net.opengis.wfs20.QueryType q = Wfs20Factory.eINSTANCE.createQueryType();
+        q.getTypeNames().addAll(Arrays.asList(new QName("http://acme.org", "foo", "acme")));
+        q.setFilter(f1);
+        gf.getAbstractQueryExpression().add(q);
+
+        q = Wfs20Factory.eINSTANCE.createQueryType();
+        q.getTypeNames().addAll(Arrays.asList(new QName("http://acme.org", "bar", "acme")));
+        gf.getAbstractQueryExpression().add(q);
+        getClass();
+        q.setFilter(f2);
+
+        Operation op = op("GetFeature", "WFS", "2.0.0", gf);
         callback.operationDispatched(new Request(), op);
 
         assertEquals("acme:foo", data.getResources().get(0));


### PR DESCRIPTION
We currently use WFS version 2.0, but the Monitor Callback has not been updated to handle the 2.0 requests yet.

Currently, they only handle:
```
DescribeFeatureTypeHandler
GetFeatureHandler
LockFeatureHandler
TransactionHandler
```
All from the package `net.opengis.wfs`

So no WFS 2.0 requests are being handled for monitoring.
We only care about `GetFeatureHandler`, so updated the handler to work with the new 2.0 version.