### PR TITLE
GSR: Ensure that objectids are always positive

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
@@ -216,7 +216,11 @@ public class FeatureEncoder {
         if (matcher.matches()) {
             return Long.parseLong(matcher.group(2));
         } else {
-            return (long) featureId.hashCode();
+            // In the case where the layer has a set PK of a different field, then chances are
+            // the featureId won't match the pattern, thus we hash the string to get a unique id.
+            // By nature of the hashcode, it will sometimes be negative, so we'll mask it to
+            // ensure a positive objectid.
+            return (long) featureId.hashCode() & 0xFFFFFFFFL;
         }
     }
 


### PR DESCRIPTION
For some layers, GSR returns a negative object id. 
This behaves weirdly in AGOL, as it maps it to massive numbers.

The only possible case where GSR could return negative numbers is when the regex doesn't match and we return the hashcode of the layer identifier.

We can set this to always be positive - which is what I have done, but then there is also a small chance/risk of duplicate ID.

- [x] First want to check why the pattern doesn't match, which is why I have added the logging.
    - This was because the layer had a PK field set to a string field. Causing the `featureId` string to not contain digits and thus not match the pattern. 