### PR TITLE
Feature Service Root: Add capabilities field

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureServiceRoot.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureServiceRoot.java
@@ -25,7 +25,8 @@ public class FeatureServiceRoot extends AbstractGSRModel implements GSRModel {
 
     public final Double currentVersion = CURRENT_VERSION;
     public final String serviceDescription;
-    public final String supportedQueryFormats = "JSON";
+    public final String supportedQueryFormats = "JSON,geojson,PBF";
+    public final String capabilities = "Query";
     public final String initialExtent = null;
     public final String fullExtent = null;
 

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/function/GSRFunctionFactoryTest.java
@@ -1,4 +1,4 @@
-package org.geoserver.gsr.controller.map;
+package org.geoserver.gsr.function;
 
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
Add the `capabilities` field to the feature service root object. 
`Query` should be the only valid capability here.
Added `geojson` and `PBF` to supported query formats aswell. 

Also fixed a bug where the `GSRFunctionFactoryTest` was initialised with the wrong package naming. 




