### PR TITLE
GSR: Improve count query performance

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureLayerController.java
@@ -226,6 +226,7 @@ public class FeatureLayerController extends AbstractGSRController {
                         whereClause,
                         false,
                         false,
+                        false,
                         null,
                         0,
                         null,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/feature/FeatureServiceController.java
@@ -174,6 +174,7 @@ public class FeatureServiceController extends QueryController {
                                     whereClause,
                                     returnGeometry,
                                     false,
+                                    false,
                                     outFieldsText,
                                     0,
                                     null,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/MapServiceController.java
@@ -207,6 +207,7 @@ public class MapServiceController extends AbstractGSRController {
                                                 null,
                                                 true,
                                                 false,
+                                                false,
                                                 null,
                                                 0,
                                                 null,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -138,6 +138,10 @@ public class QueryController extends AbstractGSRController {
             return new FeatureStatistics(features, groupByFieldsForStatistics, outStatistics);
         }
 
+        if (returnCountOnly) {
+            return FeatureEncoder.count(features, returnDistinctValues, outFieldsText);
+        }
+
         FeatureList featureList =
                 new FeatureList(
                         features,
@@ -150,12 +154,7 @@ public class QueryController extends AbstractGSRController {
                         resultOffset,
                         resultRecordCount);
 
-        // returnCountOnly should take precedence over returnIdsOnly.
-        // Sometimes both count and Ids are requested, but the count is expected in
-        // some ArcGIS softwares (e.g. AGOL) to be returned when loading attribute tables.
-        if (returnCountOnly) {
-            return FeatureEncoder.count(featureList);
-        } else if (returnIdsOnly) {
+        if (returnIdsOnly) {
             return FeatureEncoder.objectIds(featureList);
         } else {
             return featureList;

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -96,11 +96,10 @@ public class QueryController extends AbstractGSRController {
             @RequestParam(name = "outStatistics", required = false) String outStatistics)
             throws IOException {
 
-        if (returnDistinctValues && returnGeometry) {
-            throw new APIException(
-                    "InvalidParameter",
-                    "returnDistinctValues cannot be true when returnGeometry is true.",
-                    HttpStatus.BAD_REQUEST);
+        if (returnCountOnly || returnIdsOnly || returnDistinctValues) {
+            // When these are true, the client is requesting count, ids, or distinct values.
+            // Geometry is not needed, so we can save some time and resources by not calculating it.
+            returnGeometry = false;
         }
 
         LayersAndTables layersAndTables = LayerDAO.find(catalog, workspaceName, layerName);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -125,6 +125,7 @@ public class QueryController extends AbstractGSRController {
                         maxAllowableOffsets,
                         whereClause,
                         returnGeometry,
+                        returnCountOnly,
                         returnDistinctValues,
                         outFieldsText,
                         resultOffset,

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureList.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureList.java
@@ -215,20 +215,15 @@ public class FeatureList implements GSRModel {
                 && outFieldsText != null
                 && !outFieldsText.contains(FeatureEncoder.OBJECTID_FIELD_NAME)) {
             String field;
-            if (outFieldsText != null && !outFieldsText.isEmpty()) {
-                String[] outFields = outFieldsText.split(",");
-                if (outFields.length > 1) {
-                    // TODO: support multiple outFields once rebased on geoserver 2.25
-                    throw new APIException(
-                            "InvalidParameter",
-                            "Only one field can be specified when returnDistinctValues is true",
-                            HttpStatus.BAD_REQUEST);
-                }
-                field = outFields[0];
-            } else {
-                // Use the first field of the feature if outFields is not provided
-                field = fields.get(0).getName();
+            String[] outFields = outFieldsText.split(",");
+            if (outFields.length > 1) {
+                // TODO: support multiple outFields once rebased on geoserver 2.25
+                throw new APIException(
+                        "InvalidParameter",
+                        "Only one field can be specified when returnDistinctValues is true",
+                        HttpStatus.BAD_REQUEST);
             }
+            field = outFields[0];
             UniqueVisitor visitor = new UniqueVisitor(field);
             if (resultRecordCount != null) {
                 visitor.setStartIndex(resultOffset);

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
@@ -651,6 +651,7 @@ public class FeatureDAO {
                     String maxAllowableOffsets,
                     String whereClause,
                     Boolean returnGeometry,
+                    Boolean returnCountOnly,
                     Boolean returnDistinctValues,
                     String outFieldsText,
                     Integer resultOffset,
@@ -706,6 +707,7 @@ public class FeatureDAO {
                 maxAllowableOffsets,
                 whereClause,
                 returnGeometry,
+                returnCountOnly,
                 returnDistinctValues,
                 outFieldsText,
                 resultOffset,
@@ -768,6 +770,7 @@ public class FeatureDAO {
                     String whereClause,
                     Boolean returnGeometry,
                     Boolean returnDistinctValues,
+                    Boolean returnCountOnly,
                     String outFieldsText,
                     Integer resultOffset,
                     Integer resultRecordCount,
@@ -819,7 +822,9 @@ public class FeatureDAO {
         }
         query.setCoordinateSystemReproject(outSR);
 
-        if (resultRecordCount != null && !returnDistinctValues & outStatistics == null) {
+        if (resultRecordCount != null
+                && !returnDistinctValues & outStatistics == null
+                && !returnCountOnly) {
             // If returnDistinctValues/statistical query is true, we don't want to limit the number
             // of records
             query.setStartIndex(resultOffset);


### PR DESCRIPTION
Couple of performance improvements:
* If we are returning distinct values, count, or ids, set `returnGeometry` to False. This will skip fetching the geometries for each feature. 
* Return the feature count before creating the `FeatureList`. It was done this way so that we ensure that we return the count of distinct values if `returnCountOnly` and `returnDistinctValues` were used in conjunction. However, `UniqueCountVisitor` exists, so we can use this to count the distinct field values if it is used in conjunction - allowing us to skip the iterator while creating `FeatureList`. 