### PR TITLE
GSR: Support return extent only queries

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/map/QueryController.java
@@ -85,6 +85,8 @@ public class QueryController extends AbstractGSRController {
                     boolean returnCountOnly,
             @RequestParam(name = "returnDistinctValues", required = false, defaultValue = "false")
                     boolean returnDistinctValues,
+            @RequestParam(name = "returnExtentOnly", required = false, defaultValue = "false")
+                    boolean returnExtentOnly,
             @RequestParam(name = "quantizationParameters", required = false)
                     String quantizationParameters,
             @RequestParam(name = "resultRecordCount", required = false) Integer resultRecordCount,
@@ -96,8 +98,8 @@ public class QueryController extends AbstractGSRController {
             @RequestParam(name = "outStatistics", required = false) String outStatistics)
             throws IOException {
 
-        if (returnCountOnly || returnIdsOnly || returnDistinctValues) {
-            // When these are true, the client is requesting count, ids, or distinct values.
+        if (returnCountOnly || returnIdsOnly || returnDistinctValues || returnExtentOnly) {
+            // When these are true, the client is requesting count, ids, distinct values, or extent.
             // Geometry is not needed, so we can save some time and resources by not calculating it.
             returnGeometry = false;
         }
@@ -136,6 +138,15 @@ public class QueryController extends AbstractGSRController {
 
         if (groupByFieldsForStatistics != null && outStatistics != null) {
             return new FeatureStatistics(features, groupByFieldsForStatistics, outStatistics);
+        }
+
+        if (returnExtentOnly) {
+            return FeatureEncoder.extent(
+                    features,
+                    layersAndTables.layers.get(0).getExtent(),
+                    returnCountOnly,
+                    returnDistinctValues,
+                    outFieldsText);
         }
 
         if (returnCountOnly) {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureExtent.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureExtent.java
@@ -1,0 +1,35 @@
+package org.geoserver.gsr.model.feature;
+
+import org.geoserver.gsr.model.GSRModel;
+import org.geoserver.gsr.model.geometry.Envelope;
+
+public class FeatureExtent implements GSRModel {
+
+    private Envelope extent;
+    private Integer count = null;
+
+    public Envelope getExtent() {
+        return extent;
+    }
+
+    public void setExtent(Envelope extent) {
+        this.extent = extent;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public FeatureExtent(Envelope extent, Integer count) {
+        this.extent = extent;
+        this.count = count;
+    }
+
+    public FeatureExtent(Envelope extent) {
+        this(extent, null);
+    }
+}

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
@@ -47,6 +47,7 @@ public class FeatureLayer extends AbstractLayerOrTable {
         advancedQueryCapabilities.put("supportsPagination", true);
         advancedQueryCapabilities.put("supportsOrderBy", true);
         advancedQueryCapabilities.put("supportsDistinct", true);
+        advancedQueryCapabilities.put("supportsReturningQueryExtent", true);
     }
     // supportsCoordinatesQuantization - Supported (See QuantizedGeometryEncoder), but breaks ArcPRO
     // usage.

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
@@ -219,8 +219,10 @@ public class FeatureEncoder {
         if (matcher.matches()) {
             return Long.parseLong(matcher.group(2));
         } else {
-            // In the case where the layer has a set PK of a different field, then chances are
-            // the featureId won't match the pattern, thus we hash the string to get a unique id.
+            // In the case where the layer has a set PK of a different field, then chances
+            // are
+            // the featureId won't match the pattern, thus we hash the string to get a
+            // unique id.
             // By nature of the hashcode, it will sometimes be negative, so we'll mask it to
             // ensure a positive objectid.
             return (long) featureId.hashCode() & 0xFFFFFFFFL;
@@ -315,5 +317,23 @@ public class FeatureEncoder {
             count = features.size();
         }
         return new FeatureCount(count);
+    }
+
+    public static <T extends FeatureType, F extends org.opengis.feature.Feature>
+            FeatureExtent extent(
+                    FeatureCollection<T, F> features,
+                    Envelope extent,
+                    boolean includeCount,
+                    boolean returnDistinctValues,
+                    String outFieldsText)
+                    throws IOException {
+        Integer count = null;
+
+        if (includeCount) {
+            FeatureCount featureCount = count(features, returnDistinctValues, outFieldsText);
+            count = featureCount.getCount();
+        }
+
+        return new FeatureExtent(extent, count);
     }
 }

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -464,12 +464,30 @@ public class QueryControllerTest extends ControllerTest {
 
     @Test
     public void testReturnCountOnly() throws Exception {
-        String result =
-                getAsString(query("cite", 0, "?returnCountOnly=true&f=json&returnGeometry=false"));
+        String result = getAsString(query("cite", 0, "?returnCountOnly=true&f=json"));
         JSONObject json = JSONObject.fromObject(result);
         int count = json.getInt("count");
 
         assertTrue("FeatureCount result was: " + result, count == 2);
+    }
+
+    @Test
+    public void testReturnExtentOnly() throws Exception {
+        String result = getAsString(query("cite", 0, "?returnExtentOnly=true&f=json"));
+        JSONObject json = JSONObject.fromObject(result);
+        assertTrue(json.has("extent"));
+        assertFalse(json.has("count"));
+    }
+
+    @Test
+    public void testReturnExtentAndCountOnly() throws Exception {
+        String result =
+                getAsString(query("cite", 0, "?returnExtentOnly=true&returnCountOnly=true&f=json"));
+        JSONObject json = JSONObject.fromObject(result);
+        int count = json.getInt("count");
+
+        assertTrue("FeatureExtent count result was: " + result, count == 2);
+        assertTrue(json.has("extent"));
     }
 
     @Test


### PR DESCRIPTION
`/query?returnExtentOnly=true` needs to be supported.

If `true`, the response only includes the extent of the features that would be returned by the query. If `returnCountOnly=true` , the response will return both the count and the extent. The default is `false` . This parameter applies only if the `supportsReturningQueryExtent` property of the layer is `true`

Values: `true` | `false`

Ref: https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/