### PR TITLE
GSR: `returnExceededLimitFeatures` and `resultType` parameter support

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureLayer.java
@@ -48,6 +48,7 @@ public class FeatureLayer extends AbstractLayerOrTable {
         advancedQueryCapabilities.put("supportsOrderBy", true);
         advancedQueryCapabilities.put("supportsDistinct", true);
         advancedQueryCapabilities.put("supportsReturningQueryExtent", true);
+        advancedQueryCapabilities.put("supportsQueryWithResultType", true);
     }
     // supportsCoordinatesQuantization - Supported (See QuantizedGeometryEncoder), but breaks ArcPRO
     // usage.
@@ -59,6 +60,8 @@ public class FeatureLayer extends AbstractLayerOrTable {
     // feature query pagination
     protected Integer maxRecordCount = 30000;
     protected Integer maxRecordCountFactor = 1;
+    protected Integer standardMaxRecordCount = 30000;
+    protected Integer tileMaxRecordCount = 30000;
 
     // enableZDefaults - ignore
     // zDefault - ignore
@@ -131,6 +134,14 @@ public class FeatureLayer extends AbstractLayerOrTable {
 
     public Integer getMaxRecordCount() {
         return maxRecordCount;
+    }
+
+    public Integer getTileMaxRecordCount() {
+        return tileMaxRecordCount;
+    }
+
+    public Integer getStandardMaxRecordCount() {
+        return standardMaxRecordCount;
     }
 
     public Integer getMaxRecordCountFactor() {

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureList.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/model/feature/FeatureList.java
@@ -77,13 +77,15 @@ public class FeatureList implements GSRModel {
     public <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureList(
             FeatureCollection<T, F> collection, boolean returnGeometry, String outputSR)
             throws IOException {
-        this(collection, returnGeometry, false, null, outputSR, null, null, 0, null);
+        this(collection, returnGeometry, false, true, "none", null, outputSR, null, null, 0, null);
     }
 
     public <T extends FeatureType, F extends org.opengis.feature.Feature> FeatureList(
             FeatureCollection<T, F> collection,
             boolean returnGeometry,
             boolean returnDistinctValues,
+            boolean returnExceededLimitFeatures,
+            String resultType,
             String outFieldsText,
             String outputSR,
             String quantizationParameters,
@@ -258,6 +260,10 @@ public class FeatureList implements GSRModel {
             exceededTransferLimit = false;
         } else {
             exceededTransferLimit = true;
+        }
+
+        if (!returnExceededLimitFeatures && resultType.equals("tile")) {
+            features.removeIf(feature -> exceededTransferLimit);
         }
     }
 }

--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureDAO.java
@@ -29,7 +29,6 @@ import org.geoserver.gsr.model.exception.FeatureServiceErrors;
 import org.geoserver.gsr.model.exception.ServiceError;
 import org.geoserver.gsr.model.feature.EditResult;
 import org.geoserver.gsr.model.feature.EditResults;
-import org.geoserver.gsr.model.feature.FeatureLayer;
 import org.geoserver.gsr.model.geometry.SpatialReference;
 import org.geoserver.gsr.model.geometry.SpatialRelationship;
 import org.geoserver.gsr.model.map.LayerOrTable;
@@ -685,11 +684,6 @@ public class FeatureDAO {
         if (null == l) {
             throw new NoSuchElementException(
                     "No table or layer in workspace \"" + workspaceName + " for id " + layerId);
-        }
-
-        FeatureLayer featureLayer = new FeatureLayer(foundLayerOrTable);
-        if (resultRecordCount == null || resultRecordCount > featureLayer.getMaxRecordCount()) {
-            resultRecordCount = featureLayer.getMaxRecordCount();
         }
 
         return getFeatureCollectionForLayer(


### PR DESCRIPTION
Added parameters:

| Parameters | Description | Values |
| --- | --- | --- |
| `returnExceededLimitFeatures` | This option is supported by most feature services, except for feature services published using a spatiotemporal data store. This parameter is `true` by default. When set to `true` , features are returned even when the results include `exceededTransferLimit`: `true`. **When set to `false` and querying with `resultType` set to `tile` , features are not returned when the results include `exceededTransferLimit`: `true`** . This allows a client to find the resolution in which the transfer limit is no longer exceeded without making multiple calls. | Values: `true` / `false` |
| `resultType` | The `resultType` parameter can be used to control the number of features returned by the query operation. The tile value is used when the client is using a virtual tiling scheme when querying features, which works similarly to tiles in a tiled map service layer. The standard value is used with a nontiled query where the client will send only one query for the full extent. Support for this parameter is advertised on the layer metadata in the `supportsQueryWithResultType` property. For additional information on the `resultType` parameter and how it interacts with max record counts, see the [Result type and max record count](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/#return-type-and-max-record-count). | Values: `none` / `standard` / `tile` |


Now that we support `resultType`, we need a set record count for both `standard` and `tile`, given by:
- `tileMaxRecordCount`
- `standardMaxRecordCount`
Both are currently set equal to `maxRecordCount`, which is the default at 30000.

**Notable Fix:** 
- `returnExceededLimit` will be `False` in the query response **even though we have hit the default max record count**. This is causing some rendering issues with AGOL at the moment. This should be `true`
