### PR TITLE
GSR: Support multiple feature attributes for distinct value query

### DIFF
--- a/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/controller/map/QueryControllerTest.java
@@ -626,7 +626,6 @@ public class QueryControllerTest extends ControllerTest {
         JSONObject json = JSONObject.fromObject(result);
         assertTrue(json.has("error"));
 
-        // two outFields is not yet supported with returnDistinctValues
         result =
                 getAsString(
                         query(
@@ -634,7 +633,10 @@ public class QueryControllerTest extends ControllerTest {
                                 0,
                                 "?f=json&outFields=NAME,FID&returnGeometry=false&returnDistinctValues=true"));
         json = JSONObject.fromObject(result);
-        assertTrue(json.has("error"));
+        assertFalse(json.has("error"));
+        JSONArray features = json.getJSONArray("features");
+        assertEquals(2, features.size());
+        assertFalse(features.getJSONObject(0).has("geometry"));
 
         result =
                 getAsString(
@@ -644,7 +646,7 @@ public class QueryControllerTest extends ControllerTest {
                                 "?f=json&outFields=NAME&returnGeometry=false&returnDistinctValues=true"));
         json = JSONObject.fromObject(result);
         assertFalse(json.has("error"));
-        JSONArray features = json.getJSONArray("features");
+        features = json.getJSONArray("features");
         assertEquals(2, features.size());
         assertFalse(features.getJSONObject(0).has("geometry"));
     }


### PR DESCRIPTION
I.e. Enabling `outFields` to have more than one fields when doing a `returnDistinctValues=true` query.

This change requires the `UniqueVisitor` class to have the change that supports multiple attributes.
See: https://github.com/koordinates/geotools/tree/backport-3844-to-25.x

`query?f=json&where=1=1&returnDistinctValues=true&outFields=type,status`


![Screenshot 2024-10-17 at 1 58 26 PM](https://github.com/user-attachments/assets/7dfe2f74-d8a2-4578-93dc-c43ed949d84e)
