### PR TITLE
GSR PBF: Long values should be of sint64 type

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/api/GSRFeatureResultPBF.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/api/GSRFeatureResultPBF.java
@@ -146,7 +146,7 @@ public class GSRFeatureResultPBF {
                                 } else if (value instanceof Double) {
                                     valBuilder.setDoubleValue((Double) value);
                                 } else if (value instanceof Long) {
-                                    valBuilder.setInt64Value((Long) value);
+                                    valBuilder.setSint64Value((Long) value);
                                 } else if (value instanceof Float) {
                                     valBuilder.setFloatValue((Float) value);
                                 } else if (value instanceof Boolean) {


### PR DESCRIPTION
Negative values in ESRI Rest Profobuffer responses are encoded thusly:

```
      attributes {
        int64_value: -263260800000
      }
```

At the moment this specifically manifests in datetimes that are before Unix epoch (1970), ie common in things like property tiles layers.

But should be `sint64_value`. Currently this causes clients to underflow a 64bit integer which generally breaks them.